### PR TITLE
feat: add parameter to exclude properties not explicitly set by user

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ instances = engine.query_all_pages(
 for instance in instances:
     instance.aliases.append("new_alias")
 
-engine.upsert(instances, replace=False)
+engine.upsert(instances, replace=False, remove_unset=False)
 ```
 
 ---

--- a/industrial_model/cognite_adapters/__init__.py
+++ b/industrial_model/cognite_adapters/__init__.py
@@ -124,20 +124,29 @@ class CogniteAdapter:
         return data
 
     def upsert(
-        self, entries: list[TWritableViewInstance], replace: bool = False
+        self,
+        entries: list[TWritableViewInstance],
+        replace: bool = False,
+        remove_unset: bool = False,
     ) -> None:
         logger = logging.getLogger(__name__)
-        operation = self._upsert_mapper.map(entries)
+        operation = self._upsert_mapper.map(entries, remove_unset)
 
         for node_chunk in operation.chunk_nodes():
-            logger.debug(f"Upserting {len(node_chunk)} nodes (replace={replace})")
+            logger.debug(
+                f"Upserting {len(node_chunk)} nodes (replace={replace}, "
+                "remove_unset={remove_unset})"
+            )
             self._cognite_client.data_modeling.instances.apply(
                 nodes=node_chunk,
                 replace=replace,
             )
 
         for edge_chunk in operation.chunk_edges():
-            logger.debug(f"Upserting {len(edge_chunk)} edges (replace={replace})")
+            logger.debug(
+                f"Upserting {len(edge_chunk)} edges (replace={replace},"
+                "remove_unset={remove_unset})"
+            )
             self._cognite_client.data_modeling.instances.apply(
                 edges=edge_chunk,
                 replace=replace,

--- a/industrial_model/engines/async_engine.py
+++ b/industrial_model/engines/async_engine.py
@@ -55,9 +55,12 @@ class AsyncEngine:
         return await self._engine.aggregate_async(statement)
 
     async def upsert_async(
-        self, entries: list[TWritableViewInstance], replace: bool = False
+        self,
+        entries: list[TWritableViewInstance],
+        replace: bool = False,
+        remove_unset: bool = False,
     ) -> None:
-        return await self._engine.upsert_async(entries, replace)
+        return await self._engine.upsert_async(entries, replace, remove_unset)
 
     async def delete_async(self, nodes: list[TViewInstance]) -> None:
         return await self._engine.delete_async(nodes)

--- a/industrial_model/engines/engine.py
+++ b/industrial_model/engines/engine.py
@@ -98,17 +98,23 @@ class Engine:
         return await run_async(self.aggregate, statement)
 
     def upsert(
-        self, entries: list[TWritableViewInstance], replace: bool = False
+        self,
+        entries: list[TWritableViewInstance],
+        replace: bool = False,
+        remove_unset: bool = False,
     ) -> None:
         if not entries:
             return
 
-        return self._cognite_adapter.upsert(entries, replace)
+        return self._cognite_adapter.upsert(entries, replace, remove_unset)
 
     async def upsert_async(
-        self, entries: list[TWritableViewInstance], replace: bool = False
+        self,
+        entries: list[TWritableViewInstance],
+        replace: bool = False,
+        remove_unset: bool = False,
     ) -> None:
-        return await run_async(self.upsert, entries, replace)
+        return await run_async(self.upsert, entries, replace, remove_unset)
 
     def delete(self, nodes: list[TViewInstance]) -> None:
         self._cognite_adapter.delete(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "industrial-model"
-version = "1.0.1"
+version = "1.1.0"
 description = "Industrial Model ORM"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
### Summary

This PR introduces a new optional parameter to the upsert function that allows excluding properties which were not explicitly set by the user.

### Motivation

Currently, when calling upsert, all properties—including those with default values defined in the base class—are included. This makes it difficult to perform partial updates without unintentionally overwriting fields with defaults.

With this change, developers can choose to only include properties they explicitly set, leaving others untouched.

### Details

Added a new parameter: `exclude_unset`.

Default is `False`, preserving existing behavior (backward compatible).

When set to `True`, only user-defined properties are included.

### Versioning

This is a backward-compatible feature addition.

Next release version should be `1.1.0`.

### Exeample Usage:
```python
await engine.upsert_async(entities, remove_unset=True)
```