### PR TITLE
Enhance relation mode handling and update version to 1.3.0

### DIFF
--- a/industrial_model/__init__.py
+++ b/industrial_model/__init__.py
@@ -1,4 +1,5 @@
 from .config import DataModelId
+from .constants import RelationMode
 from .engines import AsyncEngine, Engine
 from .models import (
     AggregatedViewInstance,
@@ -35,6 +36,7 @@ __all__ = [
     "AsyncEngine",
     "PaginatedResult",
     "RootModel",
+    "RelationMode",
     "ViewInstanceConfig",
     "WritableViewInstance",
 ]

--- a/industrial_model/cognite_adapters/query_mapper.py
+++ b/industrial_model/cognite_adapters/query_mapper.py
@@ -59,7 +59,12 @@ class QueryMapper:
         }
         select_: dict[str, Select] = {}
 
-        relations = get_schema_properties(statement.entity, NESTED_SEP, root_node)
+        relations = get_schema_properties(
+            statement.entity,
+            NESTED_SEP,
+            root_node,
+            statement_values.relation_modes,
+        )
 
         edge_filters = self._filter_mapper.map_edges(
             statement_values.where_edge_clauses, root_view, NESTED_SEP

--- a/industrial_model/constants.py
+++ b/industrial_model/constants.py
@@ -1,5 +1,6 @@
 from typing import Literal
 
+RelationMode = Literal["instanceId", "model"]
 SORT_DIRECTION = Literal["ascending", "descending"]
 LEAF_EXPRESSION_OPERATORS = Literal[
     "==",

--- a/industrial_model/models/schemas.py
+++ b/industrial_model/models/schemas.py
@@ -1,18 +1,13 @@
-import inspect
 from collections import defaultdict
-from types import UnionType
+from functools import lru_cache
 from typing import (
     Any,
     TypeVar,
-    Union,
-    get_args,
-    get_origin,
-    get_type_hints,
 )
 
 from pydantic import BaseModel
 
-from industrial_model.constants import EDGE_MARKER, NESTED_SEP
+from industrial_model.constants import EDGE_MARKER, NESTED_SEP, RelationMode
 
 TBaseModel = TypeVar("TBaseModel", bound=BaseModel)
 
@@ -21,13 +16,41 @@ def get_schema_properties(
     cls: type[TBaseModel],
     nested_separator: str,
     prefix: str | None = None,
+    relation_modes: dict[str, RelationMode] | None = None,
 ) -> list[str]:
-    data = _get_type_properties(cls) or {}
-    keys = _flatten_dict_keys(data, None, nested_separator)
+    keys = list(_get_schema_property_paths(cls, nested_separator))
+
+    if relation_modes:
+        keys = _filter_relation_mode_keys(keys, nested_separator, relation_modes)
+
     if not prefix:
         return keys
 
-    return [f"{prefix}{nested_separator}{key}" for key in keys]
+    return [f"{prefix + nested_separator}{key}" for key in keys]
+
+
+def _filter_relation_mode_keys(
+    keys: list[str],
+    nested_separator: str,
+    relation_modes: dict[str, RelationMode],
+) -> list[str]:
+    removal_prefix_keys: list[str] = []
+    keep_keys: set[str] = set()
+    for relation_mode_key, relation_mode in relation_modes.items():
+        if relation_mode != "instanceId":
+            continue
+        entry = relation_mode_key + nested_separator
+        removal_prefix_keys.append(entry)
+        keep_keys.add(entry + "externalId")
+        keep_keys.add(entry + "space")
+
+    if not removal_prefix_keys:
+        return keys
+
+    removal_prefixes = tuple(removal_prefix_keys)
+    return [
+        key for key in keys if not key.startswith(removal_prefixes) or key in keep_keys
+    ]
 
 
 def get_parent_and_children_nodes(
@@ -55,99 +78,128 @@ def get_parent_and_children_nodes(
     return nodes_parent, dict(nodes_children)
 
 
-def _get_type_properties(
-    cls: type[BaseModel],
-    parent_type: type[BaseModel] | None = None,
-    visited_count: defaultdict[type, int] | None = None,
-) -> dict[str, Any] | None:
-    if visited_count is not None:
-        if visited_count[cls] > 1:
-            return None
-        elif parent_type == cls:
-            visited_count[cls] += 1
+@lru_cache(maxsize=256)
+def _get_schema_property_paths(
+    cls: type[BaseModel], nested_separator: str
+) -> tuple[str, ...]:
+    schema = cls.model_json_schema(by_alias=True)
+    data = _get_schema_type_properties(schema, schema) or {}
+    return tuple(_flatten_dict_keys(data, None, nested_separator))
 
-    hints = get_type_hints(cls)
-    origins = {
-        key: _get_field_type(
-            type_hint,
-            cls,
-            visited_count or defaultdict(lambda: 0),
-        )
-        for key, type_hint in hints.items()
-    }
+
+def _get_schema_type_properties(
+    root_schema: dict[str, Any],
+    schema: dict[str, Any],
+    parent_ref: str | None = None,
+    visited_count: defaultdict[str, int] | None = None,
+) -> dict[str, Any] | None:
+    current_ref = schema.get("title")
+    if "$ref" in schema:
+        resolved_ref, resolved_schema = _resolve_schema_ref(root_schema, schema["$ref"])
+        if resolved_ref is None or resolved_schema is None:
+            return None
+        current_ref = resolved_ref
+        schema = resolved_schema
+
+        if visited_count is not None:
+            if visited_count[current_ref] > 1:
+                return None
+            if parent_ref == current_ref:
+                visited_count[current_ref] += 1
 
     return {
-        field_info.alias or key: origins[key][1]
-        for key, field_info in cls.model_fields.items()
-        if key in origins
+        key: _get_schema_field_properties(
+            root_schema,
+            field_schema,
+            current_ref,
+            visited_count or defaultdict(lambda: 0),
+        )
+        for key, field_schema in schema.get("properties", {}).items()
     }
 
 
-def _get_field_type(
-    type_hint: type,
-    parent_type: type[BaseModel],
-    visited_count: defaultdict[type, int],
-) -> tuple[bool, dict[str, Any] | None]:
-    should_iter = _type_is_list_or_union(type_hint)
-
-    if not should_iter:
-        return _get_field_relations(
-            [_cast_base_model(type_hint)], parent_type, visited_count
+def _get_schema_field_properties(
+    root_schema: dict[str, Any],
+    schema: dict[str, Any],
+    parent_ref: str | None,
+    visited_count: defaultdict[str, int],
+) -> dict[str, Any] | None:
+    if "$ref" in schema:
+        return _get_schema_type_properties(
+            root_schema, schema, parent_ref, visited_count
         )
 
-    entries: list[type[BaseModel] | None] = []
-    for arg in get_args(type_hint):
-        if _type_is_list_or_union(arg):
-            return _get_field_type(arg, parent_type, visited_count)
-        entries.append(_cast_base_model(arg))
+    items = schema.get("items")
+    if isinstance(items, dict):
+        return _get_schema_field_properties(
+            root_schema, items, parent_ref, visited_count
+        )
 
-    return _get_field_relations(entries, parent_type, visited_count)
+    properties: dict[str, Any] = {}
+    for union_key in ("anyOf", "oneOf", "allOf"):
+        for option_schema in schema.get(union_key, []):
+            option_properties = _get_schema_field_properties(
+                root_schema, option_schema, parent_ref, visited_count
+            )
+            _merge_relation_properties(properties, option_properties)
 
-
-def _get_field_relations(
-    entries: list[type[TBaseModel] | None],
-    parent_type: type[BaseModel],
-    visited_count: defaultdict[type, int],
-) -> tuple[bool, dict[str, Any] | None]:
-    entry_type = next((type_ for type_ in entries if type_ is not None), None)
-
-    if not entry_type:
-        return False, None
-
-    properties = _get_type_properties(entry_type, parent_type, visited_count)
-
-    return True, properties
+    return properties or None
 
 
-def _type_is_list_or_union(entry: type) -> bool:
-    origin = get_origin(entry)
-    is_union = origin in (Union, UnionType)
-    is_list = origin in (list, list)
+def _resolve_schema_ref(
+    root_schema: dict[str, Any], ref: str
+) -> tuple[str | None, dict[str, Any] | None]:
+    defs_prefix = "#/$defs/"
+    if not ref.startswith(defs_prefix):
+        return None, None
 
-    return is_union or is_list
+    ref_name = _decode_json_pointer_token(ref.removeprefix(defs_prefix))
+    schema = root_schema.get("$defs", {}).get(ref_name)
+    return ref_name, schema if isinstance(schema, dict) else None
 
 
-def _cast_base_model(entry: type) -> type[TBaseModel] | None:
-    is_base_model = (
-        entry is not type(None)
-        and inspect.isclass(entry) is True
-        and issubclass(entry, BaseModel)
-    )
-    return entry if is_base_model else None
+def _decode_json_pointer_token(token: str) -> str:
+    return token.replace("~1", "/").replace("~0", "~")
+
+
+def _merge_relation_properties(
+    target: dict[str, Any], source: dict[str, Any] | None
+) -> None:
+    if not source:
+        return
+
+    for key, value in source.items():
+        if key not in target:
+            target[key] = value
+            continue
+
+        target_value = target[key]
+        if isinstance(target_value, dict) and isinstance(value, dict):
+            _merge_relation_properties(target_value, value)
+        elif isinstance(value, dict):
+            target[key] = value
 
 
 def _flatten_dict_keys(
     data: dict[str, Any], parent_key: str | None, nested_separator: str
 ) -> list[str]:
     paths: set[str] = set()
+    _collect_flattened_dict_keys(data, parent_key, nested_separator, paths)
+    return sorted(paths)
+
+
+def _collect_flattened_dict_keys(
+    data: dict[str, Any],
+    parent_key: str | None,
+    nested_separator: str,
+    paths: set[str],
+) -> None:
     for key, value in data.items():
         full_key = f"{parent_key}{nested_separator}{key}" if parent_key else key
         paths.add(full_key)
         if isinstance(value, dict) and value:
-            paths.update(_flatten_dict_keys(value, full_key, nested_separator))
+            _collect_flattened_dict_keys(value, full_key, nested_separator, paths)
         elif isinstance(value, str):
             paths.add(f"{full_key}{nested_separator}{value}")
         elif isinstance(value, list | set):
-            paths.update([f"{full_key}{nested_separator}{item}" for item in value])
-
-    return sorted(paths)
+            paths.update(f"{full_key}{nested_separator}{item}" for item in value)

--- a/industrial_model/queries/models.py
+++ b/industrial_model/queries/models.py
@@ -1,5 +1,8 @@
 from typing import Any
 
+from pydantic import Field
+
+from industrial_model.constants import RelationMode
 from industrial_model.models import RootModel, TAggregatedViewInstance, TViewInstance
 from industrial_model.statements import (
     AggregateTypes,
@@ -16,9 +19,13 @@ from .utils import extract_base_statement_params
 
 
 class BaseQuery(RootModel):
+    relation_modes: dict[str, RelationMode] = Field(default_factory=dict)
+
     def to_statement(self, entity: type[TViewInstance]) -> Statement[TViewInstance]:
         statement = select(entity)
         _set_base_statement_params(self, statement)
+        for relation, mode in self.relation_modes.items():
+            statement.relation_mode(relation, mode)
 
         return statement
 

--- a/industrial_model/statements/__init__.py
+++ b/industrial_model/statements/__init__.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Any, Generic, Literal, Self, TypeVar
 
-from industrial_model.constants import DEFAULT_LIMIT, SORT_DIRECTION
+from industrial_model.constants import DEFAULT_LIMIT, SORT_DIRECTION, RelationMode
 
 from .expressions import (
     BoolExpression,
@@ -32,6 +32,7 @@ class BaseStatementValues:
     sort_clauses: list[tuple[Column, SORT_DIRECTION]] = field(
         init=False, default_factory=list
     )
+    relation_modes: dict[str, RelationMode] = field(init=False, default_factory=dict)
     limit: int = field(init=False, default=DEFAULT_LIMIT)
     cursor: str | None = field(init=False, default=None)
 
@@ -99,6 +100,15 @@ class Statement(BaseStatement[T]):
                 expressions_,
             )
         )
+        return self
+
+    def relation_mode(self, property: str | Column | Any, mode: RelationMode) -> Self:
+        relation_ = (
+            _create_column(property).property
+            if not isinstance(property, str)
+            else property
+        )
+        self._values.relation_modes[relation_] = mode
         return self
 
 
@@ -193,6 +203,7 @@ __all__ = [
     "Expression",
     "LeafExpression",
     "BoolExpression",
+    "RelationMode",
     "and_",
     "not_",
     "or_",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "industrial-model"
-version = "1.2.4"
+version = "1.3.0"
 description = "Industrial Model ORM"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -48,3 +48,12 @@ def test_query() -> None:
     target = statement.get_values().where_clauses[0]
     assert isinstance(target, BoolExpression)
     assert len(target.filters) == 2
+
+
+def test_query_relation_projection() -> None:
+    statement = DescribableEntityQuery(
+        relation_modes={"parent": "instanceId"}
+    ).to_statement(CogniteDescribable)
+
+    values = statement.get_values()
+    assert values.relation_modes == {"parent": "instanceId"}

--- a/tests/test_query_mapper.py
+++ b/tests/test_query_mapper.py
@@ -1,0 +1,153 @@
+from typing import Any
+
+from cognite.client.data_classes.data_modeling import (
+    ContainerId,
+    MappedProperty,
+    View,
+    ViewId,
+)
+from cognite.client.data_classes.data_modeling.data_types import DirectRelation, Text
+from cognite.client.data_classes.data_modeling.query import Select
+
+from industrial_model.cognite_adapters.query_mapper import QueryMapper
+from industrial_model.cognite_adapters.view_mapper import ViewMapper
+from industrial_model.constants import NESTED_SEP
+from industrial_model.models import InstanceId, ViewInstance
+from industrial_model.statements import select
+
+
+class ParentType(ViewInstance):
+    code: str
+
+
+class ParentModel(ViewInstance):
+    name: str
+    type: InstanceId | ParentType | None = None
+
+
+class AssetWithRelations(ViewInstance):
+    parent: InstanceId | ParentModel | None = None
+    asset_type: InstanceId | ParentType | None = None
+
+
+class FakeViewMapper(ViewMapper):
+    def __init__(self, views: dict[str, View]) -> None:
+        self._views = views
+
+    def get_view(self, view_external_id: str) -> View:
+        return self._views[view_external_id]
+
+
+def test_query_mapper_uses_instance_id_relation_mode_to_skip_dependency_query() -> None:
+    mapper = QueryMapper(_fake_view_mapper())
+
+    query = mapper.map(
+        select(AssetWithRelations).relation_mode(
+            AssetWithRelations.parent, "instanceId"
+        )
+    )
+
+    root = AssetWithRelations.get_view_external_id()
+    assert f"{root}{NESTED_SEP}parent" not in query.with_
+    assert f"{root}{NESTED_SEP}assetType" in query.with_
+    assert _select_properties(query.select[root]) == ["parent", "assetType"]
+    assert _select_properties(query.select[f"{root}{NESTED_SEP}assetType"]) == ["code"]
+
+
+def test_query_mapper_keeps_nested_instance_id_reference_without_child_query() -> None:
+    mapper = QueryMapper(_fake_view_mapper())
+
+    query = mapper.map(
+        select(AssetWithRelations).relation_mode(
+            f"parent{NESTED_SEP}type", "instanceId"
+        )
+    )
+
+    root = AssetWithRelations.get_view_external_id()
+    parent_key = f"{root}{NESTED_SEP}parent"
+    parent_type_key = f"{parent_key}{NESTED_SEP}type"
+
+    assert parent_key in query.with_
+    assert parent_type_key not in query.with_
+    assert _select_properties(query.select[parent_key]) == ["name", "type"]
+
+
+def _fake_view_mapper() -> FakeViewMapper:
+    parent_id = _view_id(ParentModel)
+    parent_type_id = _view_id(ParentType)
+
+    return FakeViewMapper(
+        {
+            AssetWithRelations.get_view_external_id(): _view(
+                AssetWithRelations,
+                {
+                    "parent": _mapped_property(
+                        "parent", DirectRelation(), source=parent_id
+                    ),
+                    "assetType": _mapped_property(
+                        "assetType", DirectRelation(), source=parent_type_id
+                    ),
+                },
+            ),
+            ParentModel.get_view_external_id(): _view(
+                ParentModel,
+                {
+                    "name": _mapped_property("name", Text()),
+                    "type": _mapped_property(
+                        "type", DirectRelation(), source=parent_type_id
+                    ),
+                },
+            ),
+            ParentType.get_view_external_id(): _view(
+                ParentType,
+                {
+                    "code": _mapped_property("code", Text()),
+                },
+            ),
+        }
+    )
+
+
+def _view_id(model: type[ViewInstance]) -> ViewId:
+    return ViewId("space", model.get_view_external_id(), "version")
+
+
+def _view(model: type[ViewInstance], properties: dict[str, Any]) -> View:
+    return View(
+        space="space",
+        external_id=model.get_view_external_id(),
+        version="version",
+        properties=properties,
+        last_updated_time=0,
+        created_time=0,
+        description=None,
+        name=None,
+        filter=None,
+        implements=None,
+        writable=True,
+        used_for="node",
+        is_global=False,
+    )
+
+
+def _mapped_property(
+    identifier: str,
+    type_: Text | DirectRelation,
+    source: ViewId | None = None,
+) -> MappedProperty:
+    return MappedProperty(
+        container=ContainerId("space", "container"),
+        container_property_identifier=identifier,
+        type=type_,
+        nullable=True,
+        immutable=False,
+        auto_increment=False,
+        source=source,
+    )
+
+
+def _select_properties(select_: Select) -> list[str]:
+    assert len(select_.sources) == 1
+    properties = select_.sources[0].properties
+    assert properties is not None
+    return properties

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,10 @@
 from pydantic import BaseModel
 
-from industrial_model.models import get_schema_properties
+from industrial_model.models import (
+    InstanceId,
+    ViewInstance,
+    get_schema_properties,
+)
 from tests.models import (
     CogniteDescribable,
 )
@@ -21,6 +25,41 @@ class SuperNestedModel(CogniteDescribable):
     cars: list[_Car] | None
 
 
+class TimeSeries(CogniteDescribable):
+    name: str | None
+
+
+class CogniteAsset(CogniteDescribable):
+    parent: "CogniteAsset | None"
+    timeseries: InstanceId | TimeSeries
+
+
+class ParentType(ViewInstance):
+    code: str
+
+
+class ParentModel(ViewInstance):
+    name: str
+    type: InstanceId | ParentType | None = None
+
+
+class AssetWithUnionParent(ViewInstance):
+    parent: InstanceId | ParentModel | None = None
+    asset_type: InstanceId | ParentType | None = None
+
+
+class ScalarSharedRelation(ViewInstance):
+    shared: str
+
+
+class NestedSharedRelation(ViewInstance):
+    shared: ParentType
+
+
+class AssetWithOverlappingUnion(ViewInstance):
+    relation: NestedSharedRelation | ScalarSharedRelation | None = None
+
+
 def test_get_schema_properties() -> None:
     for entity, expected_schema in _get_test_schema().items():
         schema = get_schema_properties(entity, SEP)
@@ -28,6 +67,75 @@ def test_get_schema_properties() -> None:
         assert sorted(schema) == sorted(expected_schema), (
             f"{entity.__name__}: Expected {expected_schema}"
         )
+
+
+def test_build_relation_projection_instance_id_mode() -> None:
+    schema = get_schema_properties(
+        AssetWithUnionParent,
+        SEP,
+        "AssetWithUnionParent",
+        {"parent": "instanceId"},
+    )
+
+    expected_schema = [
+        "AssetWithUnionParent|externalId",
+        "AssetWithUnionParent|space",
+        "AssetWithUnionParent|parent",
+        "AssetWithUnionParent|parent|externalId",
+        "AssetWithUnionParent|parent|space",
+        "AssetWithUnionParent|assetType",
+        "AssetWithUnionParent|assetType|externalId",
+        "AssetWithUnionParent|assetType|space",
+        "AssetWithUnionParent|assetType|code",
+    ]
+
+    assert sorted(schema) == sorted(expected_schema)
+
+
+def test_build_relation_projection_model_mode_prefers_view_model_union() -> None:
+    schema = get_schema_properties(
+        AssetWithUnionParent,
+        SEP,
+        "AssetWithUnionParent",
+        {"parent": "model"},
+    )
+
+    assert "AssetWithUnionParent|parent" in schema
+    assert "AssetWithUnionParent|parent|name" in schema
+
+
+def test_build_relation_projection_includes_ancestors() -> None:
+    schema = get_schema_properties(
+        AssetWithUnionParent,
+        SEP,
+        "AssetWithUnionParent",
+        {f"parent{SEP}type": "instanceId"},
+    )
+
+    assert "AssetWithUnionParent|parent" in schema
+    assert "AssetWithUnionParent|parent|type" in schema
+    assert "AssetWithUnionParent|parent|type|externalId" in schema
+    assert "AssetWithUnionParent|parent|type|space" in schema
+    assert "AssetWithUnionParent|parent|type|code" not in schema
+
+
+def test_build_relation_projection_omits_unspecified_relations() -> None:
+    schema = get_schema_properties(
+        AssetWithUnionParent,
+        SEP,
+        "AssetWithUnionParent",
+        {"parent": "instanceId"},
+    )
+    assert "AssetWithUnionParent|parent|name" not in schema
+    assert "AssetWithUnionParent|assetType" in schema
+    assert "AssetWithUnionParent|assetType|code" in schema
+
+
+def test_schema_properties_preserve_nested_paths_in_overlapping_unions() -> None:
+    schema = get_schema_properties(AssetWithOverlappingUnion, SEP)
+
+    assert "relation|shared" in schema
+    assert "relation|shared|code" in schema
 
 
 def _get_test_schema() -> dict[type[BaseModel], list[str]]:

--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -103,6 +103,20 @@ def test_statement_where_edge() -> None:
     assert len(values.where_edge_clauses[0][1]) == 1
 
 
+def test_statement_relation_mode() -> None:
+    statement = select(TestModel).relation_mode(TestModel.name, mode="instanceId")
+
+    values = statement.get_values()
+    assert values.relation_modes == {"name": "instanceId"}
+
+
+def test_statement_without_relation_mode() -> None:
+    statement = select(TestModel)
+
+    values = statement.get_values()
+    assert values.relation_modes == {}
+
+
 def test_search_statement_creation() -> None:
     """Test creating a search statement."""
     statement = search(TestModel)

--- a/uv.lock
+++ b/uv.lock
@@ -215,7 +215,7 @@ wheels = [
 
 [[package]]
 name = "industrial-model"
-version = "1.2.4"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
- Introduced RelationMode constant for better relation management.
- Updated QueryMapper to utilize relation modes in schema properties.
- Enhanced BaseQuery to support relation modes in statements.
- Added tests for relation mode functionality and schema projections.
- Bumped version to 1.3.0 in pyproject.toml and uv.lock.