### PR TITLE
feat: add formula calculator with time-series datapoints retrieval

### DIFF
--- a/industrial_model/calculator/__init__.py
+++ b/industrial_model/calculator/__init__.py
@@ -1,0 +1,10 @@
+from .calculator import Calculator
+from .formula_expression import evaluate
+from .models import CalculationResult, CalculatorQuery
+
+__all__ = [
+    "CalculationResult",
+    "Calculator",
+    "CalculatorQuery",
+    "evaluate",
+]

--- a/industrial_model/calculator/calculator.py
+++ b/industrial_model/calculator/calculator.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import datetime
+from itertools import islice
+
+from cognite.client import CogniteClient
+
+from .datapoints_retrieval import DatapointsRetriever
+from .formula_expression import evaluate
+from .models import CalculationResult, CalculatorQuery
+
+
+class Calculator:
+    def __init__(self, cognite_client: CogniteClient) -> None:
+        self._retriever = DatapointsRetriever(cognite_client)
+
+    def calculate(
+        self, query: CalculatorQuery, start: datetime, end: datetime
+    ) -> CalculationResult:
+        return self.calculate_multiples([query], start, end)[0]
+
+    def calculate_multiples(
+        self, queries: list[CalculatorQuery], start: datetime, end: datetime
+    ) -> list[CalculationResult]:
+        datapoints = self._retriever.retrieve_datapoints(
+            [parameter for q in queries for parameter in q.parameters], start, end
+        )
+
+        it = iter(datapoints)
+        return [
+            self._calculate(query, list(islice(it, len(query.parameters))))
+            for query in queries
+        ]
+
+    def _calculate(
+        self, query: CalculatorQuery, datapoints: list[list[tuple[datetime, float]]]
+    ) -> CalculationResult:
+        values_map = {
+            param.alias: [val for _, val in series]
+            for param, series in zip(query.parameters, datapoints, strict=True)
+        }
+
+        values = list(evaluate(query.formula, values_map))
+        first_series = datapoints[0] if datapoints else []
+        timestamps = [ts for ts, _ in first_series]
+        return CalculationResult(timestamps=timestamps, values=values)

--- a/industrial_model/calculator/datapoints_retrieval.py
+++ b/industrial_model/calculator/datapoints_retrieval.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import cast
+
+from cognite.client import CogniteClient
+from cognite.client.data_classes.datapoints import Datapoints, DatapointsQuery
+
+from .models import CalculatorParameter
+
+
+class DatapointsRetriever:
+    def __init__(self, cognite_client: CogniteClient) -> None:
+        self._client = cognite_client
+
+    def retrieve_datapoints(
+        self,
+        parameters: list[CalculatorParameter],
+        start: datetime,
+        end: datetime,
+    ) -> list[list[tuple[datetime, float]]]:
+        requests, index_mapping = self._build_requests(parameters, start, end)
+        raw = self._client.time_series.data.retrieve(instance_id=requests)
+
+        return [
+            self._parse_datapoints(raw[index_mapping[idx]], parameter)
+            for idx, parameter in enumerate(parameters)
+        ]
+
+    def _build_requests(
+        self,
+        parameters: list[CalculatorParameter],
+        start: datetime,
+        end: datetime,
+    ) -> tuple[list[DatapointsQuery], dict[int, int]]:
+        dp_raw_queries: dict[tuple[str, str], DatapointsQuery] = {}
+        dp_aggregate_queries: dict[tuple[tuple[str, str], str], DatapointsQuery] = {}
+
+        requests: list[DatapointsQuery] = []
+        index_mapping: dict[int, int] = {}
+        raw_request_index: dict[tuple[str, str], int] = {}
+        agg_request_index: dict[tuple[tuple[str, str], str], int] = {}
+
+        for idx, parameter in enumerate(parameters):
+            ts_key = parameter.timeseries_instance_id.as_tuple()
+
+            if parameter.aggregate_type is None:
+                if ts_key not in dp_raw_queries:
+                    request = DatapointsQuery(
+                        instance_id=ts_key,
+                        start=start,
+                        end=end,
+                        granularity=None,
+                    )
+                    dp_raw_queries[ts_key] = request
+                    raw_request_index[ts_key] = len(requests)
+                    requests.append(request)
+                index_mapping[idx] = raw_request_index[ts_key]
+                continue
+
+            if parameter.granularity is None:
+                raise ValueError(
+                    f"""Missing granularity for '{parameter.alias}'
+                       with aggregate '{parameter.aggregate_type}'"""
+                )
+
+            agg_key = (ts_key, parameter.granularity)
+            if agg_key not in dp_aggregate_queries:
+                request = DatapointsQuery(
+                    instance_id=ts_key,
+                    aggregates=[parameter.aggregate_type],
+                    granularity=parameter.granularity,
+                    start=start,
+                    end=end,
+                )
+                dp_aggregate_queries[agg_key] = request
+                agg_request_index[agg_key] = len(requests)
+                requests.append(request)
+            else:
+                entry = dp_aggregate_queries[agg_key]
+                if not isinstance(entry.aggregates, list):
+                    raise TypeError(
+                        f"expected aggregates to be a list, "
+                        f"got {type(entry.aggregates).__name__}"
+                    )
+                if parameter.aggregate_type not in entry.aggregates:
+                    entry.aggregates.append(parameter.aggregate_type)
+
+            index_mapping[idx] = agg_request_index[agg_key]
+
+        return requests, index_mapping
+
+    def _parse_datapoints(
+        self,
+        dp: Datapoints,
+        parameter: CalculatorParameter,
+    ) -> list[tuple[datetime, float]]:
+        if not isinstance(dp, Datapoints):
+            raise TypeError(f"expected Datapoints, got {type(dp).__name__}")
+        if dp.type != "numeric":
+            raise ValueError(f"expected numeric datapoints, got {dp.type}")
+
+        col = (
+            dp.value
+            if parameter.aggregate_type is None
+            else getattr(dp, parameter.aggregate_type)
+        ) or []
+
+        if not isinstance(col, list):
+            raise TypeError(f"expected a list of values, got {type(col).__name__}")
+
+        return [
+            (datetime.fromtimestamp(ts / 1000, tz=UTC), cast(float, val))
+            for ts, val in zip(dp.timestamp or (), col, strict=False)
+            if val is not None
+        ]

--- a/industrial_model/calculator/formula_expression/__init__.py
+++ b/industrial_model/calculator/formula_expression/__init__.py
@@ -1,0 +1,3 @@
+from .core import evaluate
+
+__all__ = ["evaluate"]

--- a/industrial_model/calculator/formula_expression/_compiler.py
+++ b/industrial_model/calculator/formula_expression/_compiler.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import ast
+import functools
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import cast
+
+from ._evaluator import _BINARY_OPS, _UNARY_OPS
+from .exceptions import InvalidFormulaError
+
+_PLACEHOLDER_RE = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
+_UNRESOLVED_BRACE_RE = re.compile(r"[{}]")
+_SAFE_NAME_PREFIX = "__formula_expression_param_"
+
+_ALLOWED_AST_NODES = (
+    ast.Expression,
+    ast.BinOp,
+    ast.UnaryOp,
+    ast.Name,
+    ast.Load,
+    ast.Constant,
+)
+_ALLOWED_OPERATORS = (
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.Pow,
+    ast.Mod,
+    ast.UAdd,
+    ast.USub,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledFormula:
+    raw: str
+    expression: str
+    tree: ast.Expression
+    variables: tuple[str, ...]
+    name_map: Mapping[str, str]
+
+
+@lru_cache(maxsize=1024)
+def _compile_normalized(raw: str) -> CompiledFormula:
+    if not raw:
+        raise InvalidFormulaError("formula must not be empty")
+
+    variables: list[str] = []
+    name_map: dict[str, str] = {}
+    expression = _replace_placeholders(raw, variables, name_map)
+
+    if not variables:
+        raise InvalidFormulaError("formula must reference at least one parameter")
+
+    if _UNRESOLVED_BRACE_RE.search(expression):
+        raise InvalidFormulaError("formula contains invalid placeholder syntax")
+
+    try:
+        tree = ast.parse(expression, mode="eval")
+    except SyntaxError as exc:
+        raise InvalidFormulaError(f"invalid formula syntax: {exc.msg}") from exc
+
+    _validate_tree(tree, set(name_map.values()))
+    tree = ast.Expression(body=_fold_constants(tree.body))
+    return CompiledFormula(
+        raw=raw,
+        expression=expression,
+        tree=tree,
+        variables=tuple(variables),
+        name_map=name_map,
+    )
+
+
+class _FormulaCompiler:
+    """Normalizes the formula text, then delegates to the lru_cache'd compiler."""
+
+    def __call__(self, formula: str) -> CompiledFormula:
+        return _compile_normalized(_normalize_formula_text(formula))
+
+    def cache_clear(self) -> None:
+        _compile_normalized.cache_clear()
+
+    def cache_info(self) -> functools._CacheInfo:
+        return _compile_normalized.cache_info()
+
+
+# Expose the underlying cache controls on the public entry point so callers can
+# inspect or clear the compilation cache via ``compile_formula``.
+compile_formula = _FormulaCompiler()
+
+
+def _normalize_formula_text(formula: object) -> str:
+    if not isinstance(formula, str):
+        raise TypeError("formula must be a string")
+    return " ".join(formula.split())
+
+
+def _replace_placeholders(
+    formula: str,
+    variables: list[str],
+    name_map: dict[str, str],
+) -> str:
+    def replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name not in name_map:
+            name_map[name] = f"{_SAFE_NAME_PREFIX}{len(name_map)}"
+            variables.append(name)
+        return name_map[name]
+
+    return _PLACEHOLDER_RE.sub(replace, formula)
+
+
+def _validate_tree(tree: ast.Expression, allowed_names: set[str]) -> None:
+    for node in ast.walk(tree):
+        if not isinstance(node, _ALLOWED_AST_NODES + _ALLOWED_OPERATORS):
+            raise InvalidFormulaError(
+                f"unsupported formula element: {type(node).__name__}"
+            )
+
+        if isinstance(node, ast.Name) and node.id not in allowed_names:
+            raise InvalidFormulaError(f"unknown formula identifier: {node.id}")
+
+        if isinstance(node, ast.Constant) and (
+            isinstance(node.value, bool) or not isinstance(node.value, (int, float))
+        ):
+            raise InvalidFormulaError("only numeric constants are supported")
+
+
+def _fold_constants(node: ast.expr) -> ast.expr:
+    """Collapse constant-only subtrees to a single constant at compile time.
+
+    This runs once per formula (results are cached) so sub-expressions like
+    ``24 * 3600`` or ``0.453592`` are not recomputed on every evaluation. A fold
+    that raises (e.g. division by zero) is skipped so the original runtime error
+    semantics are preserved.
+    """
+
+    if isinstance(node, ast.BinOp):
+        node.left = _fold_constants(node.left)
+        node.right = _fold_constants(node.right)
+        if isinstance(node.left, ast.Constant) and isinstance(node.right, ast.Constant):
+            try:
+                value = _BINARY_OPS[type(node.op)](
+                    cast(float, node.left.value),
+                    cast(float, node.right.value),
+                )
+            except ArithmeticError:
+                return node
+            return ast.copy_location(ast.Constant(value=value), node)
+        return node
+
+    if isinstance(node, ast.UnaryOp):
+        node.operand = _fold_constants(node.operand)
+        if isinstance(node.operand, ast.Constant):
+            value = _UNARY_OPS[type(node.op)](cast(float, node.operand.value))
+            return ast.copy_location(ast.Constant(value=value), node)
+        return node
+
+    return node

--- a/industrial_model/calculator/formula_expression/_evaluator.py
+++ b/industrial_model/calculator/formula_expression/_evaluator.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import ast
+import operator
+from collections.abc import Callable
+from typing import TypeAlias
+
+_UNARY_OPS: dict[type[ast.unaryop], Callable[[float], float]] = {
+    ast.UAdd: operator.pos,
+    ast.USub: operator.neg,
+}
+
+
+def _safe_pow(base: float, exponent: float) -> float:
+    # Always exponentiate in float space. ``operator.pow`` on two large ints
+    # (e.g. ``10 ** 100000000``) would build an enormous integer and can hang
+    # the process, whereas float exponentiation overflows quickly with a cheap
+    # ``OverflowError``. Constant folding already coerces operands here, so this
+    # closes the only path that received raw integer constants.
+    return float(float(base) ** float(exponent))
+
+
+_BINARY_OPS: dict[type[ast.operator], Callable[[float, float], float]] = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.Pow: _safe_pow,
+    ast.Mod: operator.mod,
+}
+
+# A value is either a single scalar (broadcast across the whole series) or an
+# already-materialized per-element sequence. Keeping constant operands as
+# scalars avoids allocating length-N tuples for them and skips the element-wise
+# zip whenever one side of an operation is constant.
+Value: TypeAlias = float | tuple[float, ...]
+
+
+def evaluate_tree(
+    tree: ast.Expression,
+    environment: dict[str, tuple[float, ...]],
+    *,
+    length: int,
+) -> tuple[float, ...]:
+    result = _evaluate_node(tree.body, environment)
+    if isinstance(result, tuple):
+        return result
+    # The compiler guarantees at least one parameter, so a scalar result only
+    # happens for degenerate trees; broadcast it to the series length.
+    return (result,) * length
+
+
+def _evaluate_node(node: ast.AST, environment: dict[str, tuple[float, ...]]) -> Value:
+    if isinstance(node, ast.Name):
+        return environment[node.id]
+
+    if isinstance(node, ast.Constant):
+        # _validate_tree ensures constants are non-bool int or float.
+        assert isinstance(node.value, (int, float)) and not isinstance(node.value, bool)
+        return float(node.value)
+
+    if isinstance(node, ast.BinOp):
+        left = _evaluate_node(node.left, environment)
+        right = _evaluate_node(node.right, environment)
+        return _apply_binary(_BINARY_OPS[type(node.op)], left, right)
+
+    if isinstance(node, ast.UnaryOp):
+        operand = _evaluate_node(node.operand, environment)
+        op = _UNARY_OPS[type(node.op)]
+        if isinstance(operand, tuple):
+            return tuple(op(value) for value in operand)
+        return op(operand)
+
+    msg = f"unsupported formula element: {type(node).__name__}"
+    raise TypeError(msg)
+
+
+def _apply_binary(
+    op: Callable[[float, float], float], left: Value, right: Value
+) -> Value:
+    if isinstance(left, tuple):
+        if isinstance(right, tuple):
+            return tuple(op(lv, rv) for lv, rv in zip(left, right, strict=True))
+        return tuple(op(lv, right) for lv in left)
+    if isinstance(right, tuple):
+        return tuple(op(left, rv) for rv in right)
+    return op(left, right)

--- a/industrial_model/calculator/formula_expression/_runtime.py
+++ b/industrial_model/calculator/formula_expression/_runtime.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from ._compiler import CompiledFormula
+from ._evaluator import evaluate_tree
+from ._types import EvaluationResult, ParameterValue
+from .exceptions import MissingParameterError, ParameterError, ParameterLengthError
+
+
+def evaluate_compiled(
+    formula: CompiledFormula,
+    parameters: Mapping[str, ParameterValue],
+) -> EvaluationResult:
+    missing = [name for name in formula.variables if name not in parameters]
+    if missing:
+        raise MissingParameterError(missing)
+
+    normalized: dict[str, tuple[float, ...]] = {}
+    lengths_by_name: dict[str, int] = {}
+    for original_name, safe_name in formula.name_map.items():
+        series = _normalize_parameter(original_name, parameters[original_name])
+        normalized[safe_name] = series
+        lengths_by_name[original_name] = len(series)
+
+    if len(set(lengths_by_name.values())) != 1:
+        raise ParameterLengthError(lengths_by_name)
+
+    length = next(iter(lengths_by_name.values()))
+    if length == 0:
+        # Every referenced parameter resolved to an empty series, so there is
+        # nothing to compute over: return an empty result rather than erroring.
+        return ()
+
+    return evaluate_tree(formula.tree, normalized, length=length)
+
+
+def _normalize_parameter(name: str, value: object) -> tuple[float, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ParameterError(f"parameter {name!r} must be a numeric sequence")
+
+    normalized: list[float] = []
+    append = normalized.append
+    for item in value:
+        # Fast path for the overwhelmingly common exact ``float``/``int`` cases,
+        # falling back to ``isinstance`` only to preserve subclass acceptance
+        # (while still rejecting ``bool``).
+        item_type = type(item)
+        if item_type is float:
+            append(item)
+        elif item_type is int:
+            append(float(item))
+        elif isinstance(item, bool) or not isinstance(item, (int, float)):
+            raise ParameterError(f"parameter {name!r} must be a numeric sequence")
+        else:
+            append(float(item))
+
+    return tuple(normalized)

--- a/industrial_model/calculator/formula_expression/_types.py
+++ b/industrial_model/calculator/formula_expression/_types.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TypeAlias
+
+ParameterValue: TypeAlias = Sequence[float | int]
+EvaluationResult: TypeAlias = tuple[float, ...]

--- a/industrial_model/calculator/formula_expression/core.py
+++ b/industrial_model/calculator/formula_expression/core.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ._compiler import compile_formula
+from ._runtime import evaluate_compiled
+from ._types import EvaluationResult, ParameterValue
+
+
+def evaluate(
+    formula: str,
+    parameters: Mapping[str, ParameterValue] | None = None,
+    **kwargs: ParameterValue,
+) -> EvaluationResult:
+    """Evaluate a formula over aligned numeric parameter sequences.
+
+    Structural problems (bad syntax, unknown identifiers, missing parameters,
+    mismatched lengths, non-numeric values) raise a subclass of
+    :class:`~formula_expression.exceptions.FormulaError`.
+
+    When every referenced parameter is an empty sequence the result is an empty
+    tuple ``()`` - there is nothing to compute over, so this is treated as a
+    valid (empty) result rather than an error. A *mix* of empty and non-empty
+    parameters is still a length mismatch and raises ``ParameterLengthError``.
+
+    Arithmetic failures that depend on the parameter *values* are intentionally
+    left as their native Python exceptions and are **not** wrapped in
+    ``FormulaError``: dividing or taking a modulo by zero raises
+    ``ZeroDivisionError`` and an overflowing exponentiation raises
+    ``OverflowError`` (both subclasses of ``ArithmeticError``).
+    """
+
+    values = dict(parameters or {})
+    values.update(kwargs)
+    return evaluate_compiled(compile_formula(formula), values)

--- a/industrial_model/calculator/formula_expression/exceptions.py
+++ b/industrial_model/calculator/formula_expression/exceptions.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+class FormulaError(Exception):
+    """Base exception for formula errors."""
+
+
+class InvalidFormulaError(FormulaError):
+    """Raised when formula syntax or operations are not supported."""
+
+
+class MissingParameterError(FormulaError):
+    """Raised when a formula references parameters that were not provided."""
+
+    def __init__(self, missing: list[str]) -> None:
+        self.missing = tuple(missing)
+        joined = ", ".join(self.missing)
+        super().__init__(f"missing formula parameter(s): {joined}")
+
+
+class ParameterError(FormulaError):
+    """Raised when a parameter value is not a valid numeric sequence."""
+
+
+class ParameterLengthError(ParameterError):
+    """Raised when referenced parameters do not all share the same length."""
+
+    def __init__(self, lengths: Mapping[str, int]) -> None:
+        self.lengths = dict(lengths)
+        detail = ", ".join(
+            f"{name!r} has {length}" for name, length in self.lengths.items()
+        )
+        super().__init__(f"parameter length mismatch: {detail}")

--- a/industrial_model/calculator/models.py
+++ b/industrial_model/calculator/models.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from cognite.client.data_classes.datapoint_aggregates import Aggregate
+from pydantic import BaseModel
+
+from industrial_model.models import InstanceId
+
+
+class CalculationResult(BaseModel):
+    timestamps: list[datetime]
+    values: list[float]
+
+
+class TimeSeriesParameter(BaseModel):
+    timeseries_instance_id: InstanceId
+    aggregate_type: Aggregate | None = None
+    granularity: str | None = None
+
+
+class CalculatorParameter(TimeSeriesParameter):
+    alias: str
+
+
+class CalculatorQuery(BaseModel):
+    formula: str
+    parameters: list[CalculatorParameter]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "industrial-model"
-version = "1.7.0"
+version = "1.8.0"
 description = "Industrial Model ORM"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -47,6 +47,8 @@ Source = 'https://github.com/lucasrosaalves/industrial-model'
 
 [dependency-groups]
 dev = [
+    "InquirerPy>=0.3.4,<0.4",
+    "jinja2>=3.1.6,<4",
     "mypy>=1.20.2,<2",
     "pytest>=9.1.1,<10",
     "python-dotenv>=1.2.2,<2",

--- a/tests/calculator/formula_expression/_support.py
+++ b/tests/calculator/formula_expression/_support.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import math
+import random
+import re
+from collections.abc import Mapping, Sequence
+
+import pytest
+
+PLACEHOLDER_RE = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
+_REFERENCE_PREFIX = "__ref_param_"
+
+REPRESENTATIVE_FORMULAS = [
+    "(({APD} + {AED}) / {AVD}) - (({FPD} + {FED}) / {FVD})",
+    "{APV}/{HEADCOUNT}",
+    "({VMCM} - {FDCM} - {OFCM} - {PPCM} - {ECCM}) / {SVCM}",
+    "\t{APV} - {FPV}",
+    "{APC} + {AEC} - {FPC} - {FEC}",
+    "{VMCM} - {FDCM} - {OFCM} - {PPCM} - {ECCM}",
+    "{PRD}",
+    "{FLD}",
+    "({FGBSGRM}/1000000)+({FGBSKGM}/1000)",
+    "({RMBSGRM}/1000000)+({RMBSKGM}/1000)",
+    "{RMYVALUE} / {RMYCOUNT}",
+    "({GBSGRM}/1000000)+({GBSKGM}/1000)",
+    "({CBSGRM}/1000000)+({CBSKGM}/1000)",
+    "{COPQ}",
+    "{MAF}",
+    "{QN1PE}",
+    "{QN1P1} + {QN1P3}",
+    "{A1KG}+({A1LBS}*453592)",
+    "100 * ({AEKG}+{A0KG}+(({AELBS}+{A0LBS})*0.453592))"
+    " / ({AEKG}+{A0KG}+{A1KG}+{R1KG}+{R2KG}+{R3KG}"
+    "+(({AELBS}+{A0LBS}+{A1LBS}+{R1LBS}+{R2LBS}+{R3LBS})*0.453592))",
+    "{R1KG}+{R2KG}+{R3KG}+(({R1LBS}+{R2LBS}+{R3LBS})*0.453592)",
+    "{PCST1} + {PCST2}",
+    "(200000 * ({CPPST1} + {CPPST2}+{EPPST1} + {EPPST2})) / {TWH}",
+    "{PPST1} + {PPST2}",
+    "{ENVT1} + {ENVT2}",
+    "{FIRT1} + {FIRT2}",
+    "{HP}",
+    "{PPST3}",
+    "{NM}",
+    "(200000 * ({CPPST1} + {CPPST2})) / {CWH}",
+    "(200000 * ({EPPST1} + {EPPST2})) / {EWH}",
+    "{NMPCS}",
+    "{ITLPCST2}",
+    "{ITLPCST1}",
+    "{ITLPCST3}",
+    "{QN3}",
+    "{QN1}",
+    "{ITLPPST3}",
+    "{ITLPPST2}",
+    "{NMPPS}",
+    "{ITLEVT3}",
+    "{ITLEVT2}",
+    "{NMENV}",
+    "{ITLPPST1}",
+    "{ITLEVT1}",
+    "{NMFIR}",
+    "{ITLFIRT3}",
+    "{ITLFIRT2}",
+    "{ITLFIRT1}",
+    "{APV}",
+    "{AVLLINE} / {MSDP}",
+    "{QATLINE} / {MSDP}",
+    "{PFMLINE} / {MSDP}",
+    "{OEELINE} / {MSDP}",
+    "(24*3600) - {LLOEE} - {ALOEE} - {PLOEE} - {QLOEE}",
+    "{TEEPLINE} / {MSDP}",
+    "(24*3600) - {LLOEE}",
+    "(24*3600) - {LLOEE} - {ALOEE}",
+    "(24*3600) - {LLOEE} - {ALOEE} - {PLOEE}",
+    "{BSRMMB52}",
+    "{FGBSMB52}",
+    "{FPV}",
+    "{FPC} + {FEC}",
+    "{APC} + {AEC}",
+    "{FG}",
+    "100*({SCP})/({FG}+{IP}+{SCP})",
+    "{SCP}",
+    "{IP}",
+    "{BGEN}",
+    "{LSHR}",
+    "{PPN}",
+    "{PNY}",
+    "{TDAI}",
+]
+
+
+def parameter_names_for(formulas: list[str]) -> set[str]:
+    return {
+        variable for formula in formulas for variable in PLACEHOLDER_RE.findall(formula)
+    }
+
+
+def assert_values_equal(
+    actual: Sequence[float],
+    expected: Sequence[float],
+    *,
+    rel: float | None = None,
+    abs: float | None = None,
+) -> None:
+    assert len(actual) == len(expected)
+    for actual_value, expected_value in zip(actual, expected, strict=True):
+        if math.isnan(expected_value):
+            assert math.isnan(actual_value)
+        elif rel is not None or abs is not None:
+            assert actual_value == pytest.approx(expected_value, rel=rel, abs=abs)
+        else:
+            assert actual_value == expected_value
+
+
+def assert_values_allclose(
+    actual: Sequence[float],
+    expected: Sequence[float],
+    *,
+    rel: float = 1e-9,
+    abs: float = 1e-9,
+) -> None:
+    assert_values_equal(actual, expected, rel=rel, abs=abs)
+
+
+def reference_evaluate(
+    formula: str,
+    parameters: Mapping[str, Sequence[float]],
+) -> tuple[float, ...]:
+    """Independent oracle: evaluate the formula element-wise with Python's eval.
+
+    This is a deliberately separate implementation from the library's AST-walking
+    interpreter, so a match between the two is strong evidence of correctness.
+    """
+
+    normalized_formula = " ".join(formula.split())
+    referenced = PLACEHOLDER_RE.findall(normalized_formula)
+    expression = PLACEHOLDER_RE.sub(
+        lambda match: f"{_REFERENCE_PREFIX}{match.group(1)}", normalized_formula
+    )
+    compiled = compile(expression, "<reference>", "eval")
+
+    length = len(parameters[referenced[0]])
+    results: list[float] = []
+    for index in range(length):
+        local_env = {
+            f"{_REFERENCE_PREFIX}{name}": float(parameters[name][index])
+            for name in referenced
+        }
+        results.append(float(eval(compiled, {"__builtins__": {}}, local_env)))  # noqa: S307
+    return tuple(results)
+
+
+def random_dataset(
+    names: Sequence[str],
+    *,
+    length: int,
+    seed: int = 0,
+    low: float = 1.0,
+    high: float = 1000.0,
+) -> dict[str, list[float]]:
+    """Build a deterministic random dataset.
+
+    Values are strictly positive so that divisions and moduli in arbitrary
+    formulas never hit zero denominators.
+    """
+
+    rng = random.Random(seed)
+    return {name: [rng.uniform(low, high) for _ in range(length)] for name in names}

--- a/tests/calculator/formula_expression/conftest.py
+++ b/tests/calculator/formula_expression/conftest.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.calculator.formula_expression._support import (
+    REPRESENTATIVE_FORMULAS,
+    parameter_names_for,
+)
+
+
+@pytest.fixture
+def representative_parameters() -> dict[str, list[float]]:
+    return {name: [10.0, 20.0] for name in parameter_names_for(REPRESENTATIVE_FORMULAS)}

--- a/tests/calculator/formula_expression/test_compiler.py
+++ b/tests/calculator/formula_expression/test_compiler.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from industrial_model.calculator.formula_expression._compiler import compile_formula
+from industrial_model.calculator.formula_expression.exceptions import (
+    InvalidFormulaError,
+)
+
+
+def test_compiler_cache_reuses_compiled_formula_instances() -> None:
+    compile_formula.cache_clear()
+
+    first = compile_formula("{A} + {B}")
+    second = compile_formula("{A} + {B}")
+
+    assert first is second
+    assert compile_formula.cache_info().hits == 1
+
+
+def test_compiler_cache_miss_for_different_formulas() -> None:
+    compile_formula.cache_clear()
+
+    first = compile_formula("{A} + {B}")
+    second = compile_formula("{A} - {B}")
+
+    assert first is not second
+    assert compile_formula.cache_info().misses == 2
+
+
+def test_compiler_preserves_variable_order_without_duplicates() -> None:
+    compiled = compile_formula("{B} + {A} + {B}")
+
+    assert compiled.variables == ("B", "A")
+
+
+def test_compiler_rewrites_placeholders_to_internal_names() -> None:
+    compiled = compile_formula("{APV} - {FPV}")
+
+    assert (
+        compiled.expression
+        == "__formula_expression_param_0 - __formula_expression_param_1"
+    )
+    assert compiled.name_map == {
+        "APV": "__formula_expression_param_0",
+        "FPV": "__formula_expression_param_1",
+    }
+
+
+def test_compiler_stores_normalized_raw_formula() -> None:
+    compiled = compile_formula("\t{A}\n+\n{B} ")
+
+    assert compiled.raw == "{A} + {B}"
+
+
+def test_compiler_stores_parsed_ast_tree() -> None:
+    compiled = compile_formula("{A} + {B}")
+
+    assert isinstance(compiled.tree, ast.Expression)
+    assert isinstance(compiled.tree.body, ast.BinOp)
+
+
+def test_compiler_assigns_unique_internal_names_for_many_parameters() -> None:
+    compiled = compile_formula("{A} + {B} + {C} + {D}")
+
+    assert compiled.name_map == {
+        "A": "__formula_expression_param_0",
+        "B": "__formula_expression_param_1",
+        "C": "__formula_expression_param_2",
+        "D": "__formula_expression_param_3",
+    }
+
+
+def test_compiler_supports_parameter_names_starting_with_underscore() -> None:
+    compiled = compile_formula("{_A} + {B}")
+
+    assert compiled.variables == ("_A", "B")
+    assert "_A" in compiled.name_map
+
+
+def test_compiler_supports_parameter_names_with_digits() -> None:
+    compiled = compile_formula("{A1} + {B2}")
+
+    assert compiled.variables == ("A1", "B2")
+
+
+def test_compile_formula_rejects_empty_string() -> None:
+    with pytest.raises(InvalidFormulaError, match="must not be empty"):
+        compile_formula("")
+
+
+def test_compile_formula_rejects_non_string_input() -> None:
+    with pytest.raises(TypeError, match="formula must be a string"):
+        compile_formula(123)  # type: ignore[arg-type]
+
+
+def test_compile_formula_rejects_formula_without_parameters() -> None:
+    with pytest.raises(InvalidFormulaError, match="at least one parameter"):
+        compile_formula("1 + 2")
+
+
+def test_compile_formula_rejects_invalid_placeholder_syntax() -> None:
+    with pytest.raises(InvalidFormulaError, match="invalid placeholder syntax"):
+        compile_formula("{{A}}")

--- a/tests/calculator/formula_expression/test_edge_cases.py
+++ b/tests/calculator/formula_expression/test_edge_cases.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from industrial_model.calculator.formula_expression import evaluate
+from tests.calculator.formula_expression._support import (
+    assert_values_equal,
+)
+
+
+def test_single_parameter_passthrough() -> None:
+    result = evaluate("{VALUE}", {"VALUE": [42.0, 99.0]})
+    assert_values_equal(result, [42.0, 99.0])
+
+
+def test_operator_precedence_without_parentheses() -> None:
+    result = evaluate("{A} + {B} * {C}", {"A": [1.0], "B": [2.0], "C": [3.0]})
+    assert_values_equal(result, [7.0])
+
+
+def test_deeply_nested_parentheses() -> None:
+    result = evaluate(
+        "(({A} + ({B} * ({C} + 1))) / 2)",
+        {"A": [2.0], "B": [3.0], "C": [4.0]},
+    )
+    assert_values_equal(result, [8.5])
+
+
+def test_large_numeric_constants_from_production_formulas() -> None:
+    result = evaluate(
+        "(24*3600) - {LLOEE} - {ALOEE} - {PLOEE} - {QLOEE}",
+        {
+            "LLOEE": [100.0, 200.0],
+            "ALOEE": [50.0, 75.0],
+            "PLOEE": [25.0, 30.0],
+            "QLOEE": [10.0, 15.0],
+        },
+    )
+    assert_values_equal(result, [86215.0, 86080.0])
+
+
+def test_scientific_notation_constant() -> None:
+    result = evaluate("{A} * 1e-3", {"A": [1000.0, 2000.0]})
+    assert_values_equal(result, [1.0, 2.0])
+
+
+def test_accepts_tuple_parameters() -> None:
+    result = evaluate("{A} + {B}", {"A": (1.0, 2.0), "B": (3.0, 4.0)})
+    assert_values_equal(result, [4.0, 6.0])
+
+
+def test_accepts_range_parameters() -> None:
+    result = evaluate("{A} * 2", {"A": range(3)})
+    assert_values_equal(result, [0.0, 2.0, 4.0])
+
+
+def test_accepts_integer_values_in_sequences() -> None:
+    result = evaluate("{A} + {B}", {"A": [1, 2, 3], "B": [4, 5, 6]})
+    assert_values_equal(result, [5.0, 7.0, 9.0])
+
+
+def test_single_element_sequence() -> None:
+    result = evaluate("{A} / 4", {"A": [8.0]})
+    assert_values_equal(result, [2.0])
+
+
+def test_long_sequence_evaluation() -> None:
+    length = 1000
+    values = [float(index) for index in range(length)]
+    result = evaluate("{A} + 1", {"A": values})
+    assert len(result) == length
+    assert result[0] == 1.0
+    assert result[-1] == float(length - 1) + 1.0
+
+
+def test_division_by_zero_raises_error() -> None:
+    with pytest.raises(ZeroDivisionError):
+        evaluate("{A} / {B}", {"A": [1.0, -2.0], "B": [0.0, 0.0]})
+
+
+def test_modulo_by_zero_raises_error() -> None:
+    # Value-dependent arithmetic failures are intentionally left as native
+    # Python exceptions rather than wrapped in FormulaError.
+    with pytest.raises(ZeroDivisionError):
+        evaluate("{A} % {B}", {"A": [1.0], "B": [0.0]})
+
+
+def test_exponentiation_overflow_raises_overflow_error() -> None:
+    # Float exponentiation overflows quickly instead of building a huge int.
+    with pytest.raises(OverflowError):
+        evaluate("{A} ** 1000000000", {"A": [10.0]})
+
+
+def test_constant_only_division_by_zero_is_preserved_at_runtime() -> None:
+    # Constant folding skips subtrees that raise ArithmeticError so the runtime
+    # error semantics of a constant-only ``1 / 0`` are preserved.
+    with pytest.raises(ZeroDivisionError):
+        evaluate("{A} + 1 / 0", {"A": [1.0]})
+
+
+def test_nan_in_parameters_propagates() -> None:
+    nan = float("nan")
+    result = evaluate("{A} + {B}", {"A": [nan, 1.0], "B": [2.0, nan]})
+    assert math.isnan(result[0])
+    assert math.isnan(result[1])
+
+
+def test_negative_parameter_values() -> None:
+    result = evaluate("{A} - {B}", {"A": [-5.0, -1.0], "B": [-3.0, 2.0]})
+    assert_values_equal(result, [-2.0, -3.0])
+
+
+def test_zero_values() -> None:
+    result = evaluate(
+        "{A} * {B} + {C}", {"A": [0.0, 5.0], "B": [100.0, 0.0], "C": [1.0, 1.0]}
+    )
+    assert_values_equal(result, [1.0, 1.0])
+
+
+def test_double_unary_negation() -> None:
+    result = evaluate("-(-{A})", {"A": [3.0, -4.0]})
+    assert_values_equal(result, [3.0, -4.0])
+
+
+def test_modulo_with_floats() -> None:
+    result = evaluate("{A} % {B}", {"A": [7.5, 10.0], "B": [2.0, 3.0]})
+    assert_values_equal(result, [1.5, 1.0])
+
+
+def test_power_with_zero_exponent() -> None:
+    result = evaluate("{A} ** 0", {"A": [0.0, 5.0, -3.0]})
+    assert_values_equal(result, [1.0, 1.0, 1.0])
+
+
+def test_power_with_fractional_exponent() -> None:
+    result = evaluate("{A} ** 0.5", {"A": [4.0, 9.0]})
+    assert_values_equal(result, [2.0, 3.0])
+
+
+def test_many_parameters_in_one_formula() -> None:
+    parameters = {f"P{index}": [float(index)] for index in range(10)}
+    formula = " + ".join(f"{{P{index}}}" for index in range(10))
+    result = evaluate(formula, parameters)
+    assert_values_equal(result, [45.0])
+
+
+def test_parameter_name_with_underscore_and_digits() -> None:
+    result = evaluate("{_A1}", {"_A1": [7.0, 8.0]})
+    assert_values_equal(result, [7.0, 8.0])
+
+
+def test_result_is_tuple_not_list() -> None:
+    result = evaluate("{A} + 1", {"A": [1.0, 2.0]})
+    assert isinstance(result, tuple)
+
+
+@pytest.mark.parametrize(
+    ("formula", "parameters", "expected"),
+    [
+        ("{A} + {B} / {C}", {"A": [10.0], "B": [6.0], "C": [3.0]}, [12.0]),
+        ("({A} + {B}) / {C}", {"A": [10.0], "B": [6.0], "C": [4.0]}, [4.0]),
+        ("-{A} * +{B}", {"A": [2.0], "B": [3.0]}, [-6.0]),
+        ("{A} ** {B}", {"A": [2.0], "B": [3.0]}, [8.0]),
+        ("100 * {A} / 10", {"A": [5.0]}, [50.0]),
+    ],
+)
+def test_operator_precedence_and_forms(
+    formula: str,
+    parameters: dict[str, list[float]],
+    expected: list[float],
+) -> None:
+    result = evaluate(formula, parameters)
+    assert_values_equal(result, expected)

--- a/tests/calculator/formula_expression/test_evaluation.py
+++ b/tests/calculator/formula_expression/test_evaluation.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import pytest
+
+from industrial_model.calculator.formula_expression import evaluate
+from industrial_model.calculator.formula_expression.exceptions import (
+    ParameterLengthError,
+)
+from tests.calculator.formula_expression._support import assert_values_equal
+
+
+@pytest.mark.parametrize(
+    ("formula", "a_values", "b_values", "expected_values"),
+    [
+        ("{A} + {B} * 2", [1.0, 2.0], [3.0, 4.0], [7.0, 10.0]),
+        ("({A} + {B}) * 2", [1.0, 2.0], [3.0, 4.0], [8.0, 12.0]),
+        ("-{A} + +{B}", [5.0, 6.0], [2.0, 10.0], [-3.0, 4.0]),
+        ("{A} ** 3", [2.0, 3.0], [0.0, 0.0], [8.0, 27.0]),
+        ("{A} % {B}", [7.0, 9.0], [4.0, 5.0], [3.0, 4.0]),
+        ("\t{A}\n+\n{B} ", [2.0, 3.0], [4.0, 5.0], [6.0, 8.0]),
+    ],
+)
+def test_evaluates_series_arithmetic(
+    formula: str,
+    a_values: list[float],
+    b_values: list[float],
+    expected_values: list[float],
+) -> None:
+    result = evaluate(formula, {"A": a_values, "B": b_values})
+    assert_values_equal(result, expected_values)
+
+
+def test_evaluates_representative_series_formula() -> None:
+    parameters = {
+        "APD": [10.0, 20.0, 30.0],
+        "AED": [5.0, 10.0, 15.0],
+        "AVD": [3.0, 5.0, 9.0],
+        "FPD": [8.0, 10.0, 12.0],
+        "FED": [2.0, 4.0, 6.0],
+        "FVD": [5.0, 7.0, 9.0],
+    }
+
+    result = evaluate(
+        "(({APD} + {AED}) / {AVD}) - (({FPD} + {FED}) / {FVD})",
+        parameters,
+    )
+
+    assert_values_equal(result, [3.0, 4.0, 3.0])
+
+
+def test_reuses_repeated_parameter_in_one_expression() -> None:
+    result = evaluate("{A} + {A} * {A}", {"A": [3.0, 4.0, 5.0]})
+    assert_values_equal(result, [12.0, 20.0, 30.0])
+
+
+def test_ignores_unused_parameters() -> None:
+    result = evaluate(
+        "{A} + 1",
+        {
+            "A": [3.0, 4.0, 5.0],
+            "UNUSED": [100.0, 100.0, 100.0],
+        },
+    )
+    assert_values_equal(result, [4.0, 5.0, 6.0])
+
+
+def test_uses_numeric_constants_with_series() -> None:
+    result = evaluate("{APV}/10", {"APV": [10.0, 20.0, 30.0]})
+    assert_values_equal(result, [1.0, 2.0, 3.0])
+
+
+def test_rejects_mismatched_parameter_lengths() -> None:
+    with pytest.raises(ParameterLengthError, match="length mismatch"):
+        evaluate("{LEFT} + {RIGHT}", {"LEFT": [10.0, 20.0], "RIGHT": [1.0, 2.0, 3.0]})
+
+
+def test_preserves_series_index_for_unit_conversion() -> None:
+    result = evaluate(
+        "{A1KG}+({A1LBS}*0.453592)",
+        {"A1KG": [10.0, 20.0, 30.0], "A1LBS": [5.0, 5.0, 5.0]},
+    )
+    assert_values_equal(result, [12.26796, 22.26796, 32.26796])
+
+
+def test_result_can_mix_multiple_series_and_numeric_constants() -> None:
+    result = evaluate("({A} - {B}) / 2", {"A": [2.0, 4.0, 6.0], "B": [1.0, 2.0, 3.0]})
+    assert_values_equal(result, [0.5, 1.0, 1.5])
+
+
+def test_evaluates_formula_with_only_constants_and_one_parameter() -> None:
+    result = evaluate("100 * {A} / 10", {"A": [5.0, 10.0]})
+    assert_values_equal(result, [50.0, 100.0])
+
+
+def test_evaluates_subtraction_chain() -> None:
+    parms = {"A": [10.0, 20.0], "B": [1.0, 2.0], "C": [3.0, 4.0]}
+    result = evaluate("{A} - {B} - {C}", parms)
+    assert_values_equal(result, [6.0, 14.0])
+
+
+def test_evaluates_division_chain() -> None:
+    result = evaluate("{A} / {B} / {C}", {"A": [100.0], "B": [10.0], "C": [2.0]})
+    assert_values_equal(result, [5.0])
+
+
+def test_evaluates_mixed_scale_formula_like_production() -> None:
+    result = evaluate(
+        "(200000 * ({CPPST1} + {CPPST2})) / {CWH}",
+        {"CPPST1": [1.0, 2.0], "CPPST2": [3.0, 4.0], "CWH": [10.0, 20.0]},
+    )
+    assert_values_equal(result, [80000.0, 60000.0])
+
+
+def test_evaluates_percentage_style_formula() -> None:
+    result = evaluate(
+        "100*({SCP})/({FG}+{IP}+{SCP})",
+        {"SCP": [10.0, 20.0], "FG": [30.0, 40.0], "IP": [10.0, 10.0]},
+    )
+    assert_values_equal(result, [20.0, 28.571428571428573])

--- a/tests/calculator/formula_expression/test_exceptions.py
+++ b/tests/calculator/formula_expression/test_exceptions.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from industrial_model.calculator.formula_expression import evaluate
+from industrial_model.calculator.formula_expression.exceptions import (
+    FormulaError,
+    InvalidFormulaError,
+    MissingParameterError,
+)
+
+
+def test_missing_parameter_error_is_formula_error() -> None:
+    with pytest.raises(MissingParameterError) as exc_info:
+        evaluate("{A}", {})
+
+    assert isinstance(exc_info.value, FormulaError)
+
+
+def test_invalid_formula_error_is_formula_error() -> None:
+    with pytest.raises(InvalidFormulaError) as exc_info:
+        evaluate("{A} +")
+
+    assert isinstance(exc_info.value, FormulaError)
+
+
+def test_missing_parameter_error_exposes_missing_names() -> None:
+    error = MissingParameterError(["B", "A", "C"])
+
+    assert error.missing == ("B", "A", "C")
+    assert str(error) == "missing formula parameter(s): B, A, C"
+
+
+def test_missing_parameter_error_accepts_list_and_stores_tuple() -> None:
+    error = MissingParameterError(["X"])
+
+    assert error.missing == ("X",)
+
+
+def test_missing_parameter_error_message_includes_parameter_name() -> None:
+    with pytest.raises(MissingParameterError, match="HEADCOUNT"):
+        evaluate("{APV}/{HEADCOUNT}", {"APV": [1.0]})

--- a/tests/calculator/formula_expression/test_large_datasets.py
+++ b/tests/calculator/formula_expression/test_large_datasets.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from industrial_model.calculator.formula_expression import evaluate
+from tests.calculator.formula_expression._support import (
+    REPRESENTATIVE_FORMULAS,
+    assert_values_allclose,
+    parameter_names_for,
+    random_dataset,
+    reference_evaluate,
+)
+
+COMPLEX_FORMULAS = [
+    "(({APD} + {AED}) / {AVD}) - (({FPD} + {FED}) / {FVD})",
+    "100 * ({AEKG}+{A0KG}+(({AELBS}+{A0LBS})*0.453592)) / "
+    "({AEKG}+{A0KG}+{A1KG}+{R1KG}+{R2KG}+{R3KG}+"
+    "(({AELBS}+{A0LBS}+{A1LBS}+{R1LBS}+{R2LBS}+{R3LBS})*0.453592))",
+    "(200000 * ({CPPST1} + {CPPST2}+{EPPST1} + {EPPST2})) / {TWH}",
+    "100*({SCP})/({FG}+{IP}+{SCP})",
+    "({VMCM} - {FDCM} - {OFCM} - {PPCM} - {ECCM}) / {SVCM}",
+    "(24*3600) - {LLOEE} - {ALOEE} - {PLOEE} - {QLOEE}",
+    "{R1KG}+{R2KG}+{R3KG}+(({R1LBS}+{R2LBS}+{R3LBS})*0.453592)",
+    "((({A} + {B}) * ({C} - {D})) / (({E} + 1) * ({F} + 1))) ** 2 + {G} % {H}",
+]
+
+
+@pytest.mark.parametrize("formula", COMPLEX_FORMULAS, ids=lambda f: f[:40])
+def test_complex_formula_matches_reference_on_large_dataset(formula: str) -> None:
+    names = sorted(parameter_names_for([formula]))
+    parameters = random_dataset(names, length=10_000, seed=17)
+
+    result = evaluate(formula, parameters)
+    expected = reference_evaluate(formula, parameters)
+
+    assert len(result) == 10_000
+    assert_values_allclose(result, expected, rel=1e-9, abs=1e-9)
+
+
+@pytest.mark.parametrize(
+    "formula",
+    REPRESENTATIVE_FORMULAS,
+    ids=lambda f: f.strip().replace(" ", "")[:40],
+)
+def test_all_representative_formulas_match_reference_on_large_dataset(
+    formula: str,
+) -> None:
+    names = sorted(parameter_names_for([formula]))
+    parameters = random_dataset(names, length=2_000, seed=29)
+
+    result = evaluate(formula, parameters)
+    expected = reference_evaluate(formula, parameters)
+
+    assert_values_allclose(result, expected, rel=1e-9, abs=1e-9)
+
+
+def test_evaluates_100k_point_dataset_correctly() -> None:
+    length = 100_000
+    parameters = random_dataset(["A", "B", "C"], length=length, seed=3)
+
+    result = evaluate("({A} + {B}) * {C} - {A}", parameters)
+
+    assert len(result) == length
+    expected = reference_evaluate("({A} + {B}) * {C} - {A}", parameters)
+    assert_values_allclose(result, expected, rel=1e-9, abs=1e-9)
+
+
+def test_evaluation_scales_to_large_dataset_within_time_budget() -> None:
+    parameters = random_dataset(["A", "B", "C", "D", "E"], length=200_000, seed=5)
+    formula = "({A} + {B}) * {C} - {D} / {E}"
+
+    start = time.perf_counter()
+    result = evaluate(formula, parameters)
+    elapsed = time.perf_counter() - start
+
+    assert len(result) == 200_000
+    # Generous bound; pure-Python evaluation of 200k points stays well under this.
+    assert elapsed < 10.0
+
+
+def test_repeated_parameter_reuse_on_large_dataset() -> None:
+    parameters = random_dataset(["A"], length=5_000, seed=11)
+    formula = "{A} * {A} - {A} + ({A} / {A})"
+
+    result = evaluate(formula, parameters)
+    expected = reference_evaluate(formula, parameters)
+
+    assert_values_allclose(result, expected, rel=1e-9, abs=1e-9)
+
+
+def test_deeply_nested_formula_matches_reference() -> None:
+    formula = "(((({A} + {B}) * {C}) - {D}) / {E}) + (({F} - {G}) * ({H} + {I}))"
+    names = sorted(parameter_names_for([formula]))
+    parameters = random_dataset(names, length=4_000, seed=23)
+
+    result = evaluate(formula, parameters)
+    expected = reference_evaluate(formula, parameters)
+
+    assert_values_allclose(result, expected, rel=1e-9, abs=1e-9)
+
+
+def test_evaluation_is_deterministic_across_runs() -> None:
+    parameters = random_dataset(["A", "B"], length=3_000, seed=7)
+    formula = "({A} * 2 + {B}) / 3"
+
+    first = evaluate(formula, parameters)
+    second = evaluate(formula, parameters)
+
+    assert first == second
+
+
+def test_addition_is_commutative_on_large_dataset() -> None:
+    parameters = random_dataset(["A", "B"], length=5_000, seed=31)
+
+    left = evaluate("{A} + {B}", parameters)
+    right = evaluate("{B} + {A}", parameters)
+
+    assert_values_allclose(left, right, rel=1e-12, abs=1e-12)
+
+
+def test_multiplication_distributes_over_addition_on_large_dataset() -> None:
+    parameters = random_dataset(["A", "B", "C"], length=5_000, seed=37)
+
+    distributed = evaluate("{A} * ({B} + {C})", parameters)
+    expanded = evaluate("{A} * {B} + {A} * {C}", parameters)
+
+    assert_values_allclose(distributed, expanded, rel=1e-9, abs=1e-9)
+
+
+def test_additive_identity_on_large_dataset() -> None:
+    parameters = random_dataset(["A"], length=5_000, seed=41)
+
+    result = evaluate("{A} + 0", parameters)
+
+    assert_values_allclose(result, tuple(parameters["A"]), rel=1e-12, abs=1e-12)
+
+
+def test_multiplicative_identity_on_large_dataset() -> None:
+    parameters = random_dataset(["A"], length=5_000, seed=43)
+
+    result = evaluate("{A} * 1", parameters)
+
+    assert_values_allclose(result, tuple(parameters["A"]), rel=1e-12, abs=1e-12)
+
+
+def test_self_subtraction_is_zero_on_large_dataset() -> None:
+    parameters = random_dataset(["A"], length=5_000, seed=47)
+
+    result = evaluate("{A} - {A}", parameters)
+
+    assert all(value == 0.0 for value in result)
+
+
+def test_self_division_is_one_on_large_dataset() -> None:
+    parameters = random_dataset(["A"], length=5_000, seed=53)
+
+    result = evaluate("{A} / {A}", parameters)
+
+    assert_values_allclose(result, [1.0] * 5_000, rel=1e-12, abs=1e-12)

--- a/tests/calculator/formula_expression/test_public_api.py
+++ b/tests/calculator/formula_expression/test_public_api.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import industrial_model.calculator.formula_expression as formula_expression
+from industrial_model.calculator.formula_expression import evaluate
+from tests.calculator.formula_expression._support import assert_values_equal
+
+
+def test_package_exports_only_evaluate() -> None:
+    assert formula_expression.__all__ == ["evaluate"]
+    assert formula_expression.evaluate is evaluate
+
+
+def test_private_helpers_are_not_exported_at_package_top_level() -> None:
+    assert not hasattr(formula_expression, "compile_formula")
+    assert not hasattr(formula_expression, "Formula")
+    assert not hasattr(formula_expression, "FormulaError")
+
+
+def test_keyword_parameters_are_supported_for_simple_calls() -> None:
+    result = evaluate(
+        "{APV} - {FPV}",
+        APV=[10.0, 20.0],
+        FPV=[3.0, 5.0],
+    )
+    assert_values_equal(result, [7.0, 15.0])
+
+
+def test_keyword_parameters_override_mapping_values() -> None:
+    result = evaluate(
+        "{APV} - {FPV}",
+        {
+            "APV": [10.0, 20.0],
+            "FPV": [9.0, 9.0],
+        },
+        FPV=[3.0, 5.0],
+    )
+    assert_values_equal(result, [7.0, 15.0])
+
+
+def test_evaluate_accepts_mapping_subclass() -> None:
+    class ParameterMapping(dict[str, list[float]]):
+        pass
+
+    result = evaluate(
+        "{A} + {B}",
+        ParameterMapping({"A": [1.0, 2.0], "B": [3.0, 4.0]}),
+    )
+    assert_values_equal(result, [4.0, 6.0])
+
+
+def test_evaluate_returns_new_tuple_each_call() -> None:
+    first = evaluate("{A} + 1", {"A": [1.0]})
+    second = evaluate("{A} + 1", {"A": [1.0]})
+    assert first == second
+    assert first is not second

--- a/tests/calculator/formula_expression/test_representative_formulas.py
+++ b/tests/calculator/formula_expression/test_representative_formulas.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pytest
+
+from industrial_model.calculator.formula_expression import evaluate
+from tests.calculator.formula_expression._support import (
+    REPRESENTATIVE_FORMULAS,
+    assert_values_equal,
+    parameter_names_for,
+)
+
+
+def formula_id(formula: str) -> str:
+    return formula.strip().replace(" ", "")[:50]
+
+
+def test_representative_fixture_contains_unique_formulas() -> None:
+    assert len(REPRESENTATIVE_FORMULAS) == len(set(REPRESENTATIVE_FORMULAS))
+
+
+def test_representative_fixture_contains_expected_parameters() -> None:
+    parameter_names = parameter_names_for(REPRESENTATIVE_FORMULAS)
+
+    assert {"APV", "HEADCOUNT", "A1KG", "A1LBS", "TDAI"} <= parameter_names
+
+
+@pytest.mark.parametrize(
+    "formula",
+    REPRESENTATIVE_FORMULAS,
+    ids=formula_id,
+)
+def test_evaluates_all_representative_formulas_without_error(
+    formula: str,
+    representative_parameters: dict[str, list[float]],
+) -> None:
+    result = evaluate(formula, representative_parameters)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "{PRD}",
+        "{FLD}",
+        "{HP}",
+        "{NM}",
+        "{APV}",
+        "{FPV}",
+        "{FG}",
+        "{SCP}",
+        "{IP}",
+        "{BGEN}",
+        "{LSHR}",
+        "{PPN}",
+        "{PNY}",
+        "{TDAI}",
+    ],
+)
+def test_evaluates_single_parameter_production_formulas(
+    formula: str,
+    representative_parameters: dict[str, list[float]],
+) -> None:
+    result = evaluate(formula, representative_parameters)
+
+    assert_values_equal(result, [10.0, 20.0])
+
+
+@pytest.mark.parametrize(
+    ("formula", "expected"),
+    [
+        ("{APV}/{HEADCOUNT}", [1.0, 1.0]),
+        ("{APC} + {AEC} - {FPC} - {FEC}", [0.0, 0.0]),
+        ("{PCST1} + {PCST2}", [20.0, 40.0]),
+        ("{PPST1} + {PPST2}", [20.0, 40.0]),
+        ("{ENVT1} + {ENVT2}", [20.0, 40.0]),
+        ("{FIRT1} + {FIRT2}", [20.0, 40.0]),
+        ("{QN1P1} + {QN1P3}", [20.0, 40.0]),
+        ("({FGBSGRM}/1000000)+({FGBSKGM}/1000)", [0.01001, 0.02002]),
+        ("{AVLLINE} / {MSDP}", [1.0, 1.0]),
+        ("(24*3600) - {LLOEE}", [86390.0, 86380.0]),
+    ],
+)
+def test_evaluates_selected_production_formulas_with_expected_values(
+    formula: str,
+    expected: list[float],
+    representative_parameters: dict[str, list[float]],
+) -> None:
+    result = evaluate(formula, representative_parameters)
+    assert_values_equal(result, expected)

--- a/tests/calculator/formula_expression/test_runtime.py
+++ b/tests/calculator/formula_expression/test_runtime.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import pytest
+
+from industrial_model.calculator.formula_expression import evaluate
+from industrial_model.calculator.formula_expression.exceptions import (
+    FormulaError,
+    ParameterError,
+    ParameterLengthError,
+)
+
+
+def test_all_empty_parameter_sequences_return_empty_result() -> None:
+    assert evaluate("{A} + 1", {"A": []}) == ()
+
+
+def test_all_empty_multi_parameter_sequences_return_empty_result() -> None:
+    assert evaluate("{A} + {B}", {"A": [], "B": []}) == ()
+
+
+def test_mixed_empty_and_non_empty_parameters_raise_length_error() -> None:
+    with pytest.raises(ParameterLengthError, match="length mismatch"):
+        evaluate("{A} + {B}", {"A": [], "B": [1.0]})
+
+
+def test_rejects_bytes_parameter_values() -> None:
+    with pytest.raises(ParameterError, match="numeric sequence"):
+        evaluate("{A} + 1", {"A": b"\x01\x02"})
+
+
+def test_rejects_string_parameter_values() -> None:
+    with pytest.raises(ParameterError, match="numeric sequence"):
+        evaluate("{A} + 1", {"A": "12"})  # type: ignore[dict-item]
+
+
+def test_rejects_none_parameter_value() -> None:
+    with pytest.raises(ParameterError, match="numeric sequence"):
+        evaluate("{A} + 1", {"A": None})  # type: ignore[dict-item]
+
+
+def test_rejects_dict_parameter_value() -> None:
+    with pytest.raises(ParameterError, match="numeric sequence"):
+        evaluate("{A} + 1", {"A": {"x": 1.0}})  # type: ignore[dict-item]
+
+
+def test_rejects_nested_sequence_parameter_value() -> None:
+    with pytest.raises(ParameterError, match="numeric sequence"):
+        evaluate("{A} + 1", {"A": [[1.0, 2.0]]})  # type: ignore[list-item]
+
+
+def test_rejects_mismatched_lengths_with_three_parameters() -> None:
+    with pytest.raises(ParameterLengthError, match="length mismatch"):
+        evaluate(
+            "{A} + {B} + {C}",
+            {"A": [1.0, 2.0], "B": [1.0, 2.0, 3.0], "C": [1.0, 2.0]},
+        )
+
+
+def test_length_mismatch_error_reports_names_and_lengths() -> None:
+    with pytest.raises(ParameterLengthError) as exc_info:
+        evaluate("{A} + {B}", {"A": [1.0, 2.0], "B": [1.0, 2.0, 3.0]})
+
+    assert exc_info.value.lengths == {"A": 2, "B": 3}
+    assert "'A' has 2" in str(exc_info.value)
+    assert "'B' has 3" in str(exc_info.value)
+
+
+def test_length_mismatch_ignores_unused_parameters() -> None:
+    result = evaluate(
+        "{A} + 1",
+        {"A": [1.0, 2.0], "UNUSED": [1.0, 2.0, 3.0, 4.0]},
+    )
+    assert result == (2.0, 3.0)
+
+
+def test_parameter_errors_are_formula_errors() -> None:
+    assert issubclass(ParameterError, FormulaError)
+    assert issubclass(ParameterLengthError, ParameterError)
+
+
+def test_parameter_error_message_includes_parameter_name() -> None:
+    with pytest.raises(ParameterError, match="parameter 'A'"):
+        evaluate("{A} + 1", {"A": [1.0, "x"]})  # type: ignore[list-item]
+
+
+def test_evaluate_with_kwargs_only() -> None:
+    result = evaluate("{A} + {B}", A=[1.0, 2.0], B=[3.0, 4.0])
+    assert result == (4.0, 6.0)
+
+
+def test_evaluate_with_empty_mapping_and_kwargs() -> None:
+    result = evaluate("{X} * 2", {}, X=[5.0])
+    assert result == (10.0,)
+
+
+def test_evaluate_with_none_parameters_and_kwargs() -> None:
+    result = evaluate("{X} + 1", None, X=[2.0])
+    assert result == (3.0,)

--- a/tests/calculator/formula_expression/test_validation.py
+++ b/tests/calculator/formula_expression/test_validation.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import pytest
+
+from industrial_model.calculator.formula_expression import evaluate
+from industrial_model.calculator.formula_expression.exceptions import (
+    InvalidFormulaError,
+    MissingParameterError,
+    ParameterError,
+)
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "__import__('os').system('echo unsafe')",
+        "{A}.__class__",
+        "{A}[0]",
+        "{A} if {A} else 0",
+        "{A} < 10",
+        "'text'",
+        "{A",
+        "{A B}",
+        "{A} // 2",
+        "[{A}]",
+        "{A} and {B}",
+        "lambda x: x",
+        "eval('1')",
+        "{A}({B})",
+        "{A} + {B}; {A}",
+        "for x in {A}: x",
+        "{A} += 1",
+        "{A} | {B}",
+        "{A} & {B}",
+        "{A} ^ {B}",
+        "{A} << 1",
+        "{A} >> 1",
+        "~{A}",
+        "not {A}",
+        "{A} is {B}",
+        "{A} in {B}",
+        "{A} == {B}",
+        "{A} != {B}",
+        "{A} >= {B}",
+        "{A} <= {B}",
+        "{A} > {B}",
+        "f'{A}'",
+        "{A}: {B}",
+        "{A} + ...",
+        "... + {A}",
+        "{A} + None",
+        "{A} + {B}.real",
+        "({A}) for {B} in {C}",
+    ],
+)
+def test_rejects_unsafe_or_unsupported_formula_syntax(formula: str) -> None:
+    with pytest.raises(InvalidFormulaError):
+        evaluate(formula)
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "{}",
+        "{{A}}",
+        "{A}{B}",
+        "{123}",
+        "{A + B}",
+        "{A-B}",
+        "{A.B}",
+        "{A@B}",
+    ],
+)
+def test_rejects_invalid_placeholder_syntax(formula: str) -> None:
+    with pytest.raises(InvalidFormulaError):
+        evaluate(formula)
+
+
+def test_rejects_invalid_formula_syntax_with_message() -> None:
+    with pytest.raises(InvalidFormulaError, match="invalid formula syntax"):
+        evaluate("{A} +* {B}")
+
+
+def test_rejects_unresolved_braces_after_replacement() -> None:
+    with pytest.raises(InvalidFormulaError, match="invalid placeholder syntax"):
+        evaluate("{{A}}")
+
+
+@pytest.mark.parametrize("formula", ["{A} + True", "{A} + False", "{A} + None"])
+def test_rejects_non_numeric_constants(formula: str) -> None:
+    with pytest.raises(InvalidFormulaError, match="numeric constants"):
+        evaluate(formula, {"A": [1.0, 2.0]})
+
+
+def test_rejects_formula_without_parameters() -> None:
+    with pytest.raises(InvalidFormulaError, match="at least one parameter"):
+        evaluate("1 + 2 * 3")
+
+
+def test_rejects_constant_only_expression_with_no_placeholders() -> None:
+    with pytest.raises(InvalidFormulaError, match="at least one parameter"):
+        evaluate("42")
+
+
+def test_rejects_whitespace_only_formula() -> None:
+    with pytest.raises(InvalidFormulaError, match="must not be empty"):
+        evaluate("   ")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        ["x", "y"],
+        [True, False],
+        [1.0, None],
+        [1.0, "2"],
+    ],
+)
+def test_rejects_non_numeric_sequences(value: list[object]) -> None:
+    with pytest.raises(ParameterError, match="numeric sequence"):
+        evaluate("{A} + 1", {"A": value})  # type: ignore[dict-item]
+
+
+@pytest.mark.parametrize("value", [object(), "1", True, 3.14, {"A": 1}])
+def test_rejects_invalid_parameter_values(value: object) -> None:
+    with pytest.raises(ParameterError, match="numeric sequence"):
+        evaluate("{A} + 1", {"A": value})  # type: ignore[dict-item]
+
+
+def test_rejects_non_string_formula() -> None:
+    with pytest.raises(TypeError, match="formula must be a string"):
+        evaluate(123)  # type: ignore[arg-type]
+
+
+def test_raises_for_single_missing_parameter() -> None:
+    with pytest.raises(MissingParameterError) as exc_info:
+        evaluate("{A} + {B}", {"A": [1.0, 2.0]})
+
+    assert exc_info.value.missing == ("B",)
+    assert str(exc_info.value) == "missing formula parameter(s): B"
+
+
+def test_raises_for_all_missing_parameters_in_formula_order() -> None:
+    with pytest.raises(MissingParameterError) as exc_info:
+        evaluate("{B} + {A} + {B}")
+
+    assert exc_info.value.missing == ("B", "A")
+
+
+def test_raises_for_missing_parameter_when_extra_parameters_provided() -> None:
+    with pytest.raises(MissingParameterError) as exc_info:
+        evaluate("{A} + {B}", {"A": [1.0], "C": [2.0]})
+
+    assert exc_info.value.missing == ("B",)
+
+
+def test_rejects_unknown_identifier_outside_placeholder() -> None:
+    with pytest.raises(InvalidFormulaError, match="unknown formula identifier"):
+        evaluate("{A} + B")

--- a/tests/calculator/test_calculator.py
+++ b/tests/calculator/test_calculator.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from cognite.client.data_classes.datapoint_aggregates import Aggregate
+from cognite.client.data_classes.datapoints import Datapoints, DatapointsList
+
+from industrial_model.calculator import (
+    Calculator,
+)
+from industrial_model.calculator.formula_expression.exceptions import ParameterError
+from industrial_model.calculator.models import (
+    CalculationResult,
+    CalculatorParameter,
+    CalculatorQuery,
+)
+from industrial_model.models import InstanceId
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_START = datetime(2024, 1, 1, tzinfo=UTC)
+_END = datetime(2024, 1, 2, tzinfo=UTC)
+
+
+def _make_param(
+    alias: str, space: str = "s", external_id: str = "x"
+) -> CalculatorParameter:
+    return CalculatorParameter(
+        alias=alias,
+        timeseries_instance_id=InstanceId(space=space, external_id=external_id),
+    )
+
+
+def _make_param_with_aggregate(
+    alias: str,
+    aggregate: Aggregate,
+    granularity: str | None = None,
+    space: str = "s",
+    external_id: str = "x",
+) -> CalculatorParameter:
+    return CalculatorParameter(
+        alias=alias,
+        timeseries_instance_id=InstanceId(space=space, external_id=external_id),
+        aggregate_type=aggregate,
+        granularity=granularity,
+    )
+
+
+def _make_query(
+    formula: str,
+    parameters: list[CalculatorParameter],
+) -> CalculatorQuery:
+    return CalculatorQuery(
+        formula=formula,
+        parameters=parameters,
+    )
+
+
+def _make_datapoints(
+    values: list[float] | None,
+    space: str = "s",
+    external_id: str = "x",
+    timestamps: list[int] | None = None,
+) -> Datapoints:
+    return Datapoints(
+        id=1,
+        is_string=False,
+        is_step=False,
+        type="numeric",
+        external_id=external_id,
+        instance_id=MagicMock(space=space, external_id=external_id),
+        timestamp=timestamps,
+        value=values,
+    )
+
+
+def _ms(moment: datetime) -> int:
+    return int(moment.timestamp() * 1000)
+
+
+# ---------------------------------------------------------------------------
+# Calculator.calculate – shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_datapoints_list(
+    entries: dict[tuple[str, str], list[float]],
+    timestamps: dict[tuple[str, str], list[int]] | None = None,
+) -> MagicMock:
+    """A stand-in for ``DatapointsList`` that resolves items by insertion-order index.
+
+    Timestamps default to one-minute steps starting at ``_START`` so that every
+    value falls inside the default ``[_START, _END)`` query window.
+    """
+
+    raw = MagicMock(spec=DatapointsList)
+    base = _ms(_START)
+    timestamps = timestamps or {}
+    data_list = [
+        _make_datapoints(
+            values,
+            space=instance[0],
+            external_id=instance[1],
+            timestamps=timestamps.get(
+                instance, [base + i * 60_000 for i in range(len(values))]
+            ),
+        )
+        for instance, values in entries.items()
+    ]
+    raw.__getitem__.side_effect = lambda idx: data_list[idx]
+    return raw
+
+
+def _client_returning(raw: MagicMock) -> MagicMock:
+    client = MagicMock()
+    client.time_series.data.retrieve.return_value = raw
+    return client
+
+
+def _make_aggregate_datapoints_list(
+    instance: tuple[str, str],
+    aggregate: str,
+    values: list[float],
+) -> MagicMock:
+    """A ``DatapointsList`` stand-in holding a single aggregate series."""
+
+    base = _ms(_START)
+    dp = Datapoints(
+        id=1,
+        is_string=False,
+        is_step=False,
+        type="numeric",
+        external_id=instance[1],
+        instance_id=MagicMock(space=instance[0], external_id=instance[1]),
+        timestamp=[base + i * 60_000 for i in range(len(values))],
+    )
+    setattr(dp, aggregate, values)
+    raw = MagicMock(spec=DatapointsList)
+    raw.__getitem__.side_effect = lambda idx: dp if idx == 0 else None
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Calculator.calculate – happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_calculate_returns_evaluation_result_for_simple_formula() -> None:
+    param = _make_param("A", external_id="ts1")
+    raw = _make_datapoints_list({("s", "ts1"): [1.0, 2.0, 3.0]})
+
+    calc = Calculator(_client_returning(raw))
+    result = calc.calculate(_make_query("{A} * 2", [param]), _START, _END)
+
+    assert list(result.values) == [2.0, 4.0, 6.0]
+
+
+def test_calculate_passes_window_to_client() -> None:
+    param = _make_param("A")
+    raw = _make_datapoints_list({("s", "x"): [5.0]})
+
+    client = _client_returning(raw)
+    Calculator(client).calculate(_make_query("{A}", [param]), _START, _END)
+
+    dp_query = client.time_series.data.retrieve.call_args.kwargs["instance_id"][0]
+    assert dp_query.start == _START
+    assert dp_query.end == _END
+
+
+def test_calculate_multi_parameter_formula() -> None:
+    p_a = _make_param("A", external_id="ts_a")
+    p_b = _make_param("B", external_id="ts_b")
+
+    raw = _make_datapoints_list(
+        {("s", "ts_a"): [10.0, 20.0], ("s", "ts_b"): [2.0, 4.0]}
+    )
+
+    calc = Calculator(_client_returning(raw))
+    result = calc.calculate(_make_query("{A} / {B}", [p_a, p_b]), _START, _END)
+
+    assert list(result.values) == [5.0, 5.0]
+
+
+def test_calculate_with_aggregate_passes_granularity_in_query() -> None:
+    param = _make_param_with_aggregate("A", aggregate="average", granularity="1h")
+    raw = _make_aggregate_datapoints_list(("s", "x"), "average", [10.0, 20.0])
+
+    client = _client_returning(raw)
+    Calculator(client).calculate(_make_query("{A}", [param]), _START, _END)
+
+    queries_arg = client.time_series.data.retrieve.call_args.kwargs["instance_id"]
+    assert queries_arg[0].granularity == "1h"
+
+
+def test_calculate_non_aggregate_parameter_has_no_granularity_in_query() -> None:
+    param = _make_param("A")
+    raw = _make_datapoints_list({("s", "x"): [1.0]})
+
+    client = _client_returning(raw)
+    Calculator(client).calculate(_make_query("{A}", [param]), _START, _END)
+
+    queries_arg = client.time_series.data.retrieve.call_args.kwargs["instance_id"]
+    assert queries_arg[0].granularity is None
+
+
+def test_calculate_returns_empty_result_when_data_missing_for_parameter() -> None:
+    param = _make_param("A")
+    raw = _make_datapoints_list({("s", "x"): []})  # exists but has no values in window
+
+    # A timeseries with no data in the window is treated as an empty series
+    calc = Calculator(_client_returning(raw))
+    result = calc.calculate(_make_query("{A}", [param]), _START, _END)
+    assert result == CalculationResult(timestamps=[], values=[])
+
+
+# ---------------------------------------------------------------------------
+# Calculator.calculate – deduplication
+# ---------------------------------------------------------------------------
+
+
+def test_calculate_deduplicates_identical_parameter_requests() -> None:
+    # Two parameters in one formula referencing the same timeseries (same
+    # aggregate/granularity) should be fetched a single time.
+    p1 = _make_param("A", external_id="ts_a")
+    p2 = _make_param("B", external_id="ts_a")
+
+    raw = _make_datapoints_list({("s", "ts_a"): [3.0, 6.0]})
+    client = _client_returning(raw)
+    calc = Calculator(client)
+
+    result = calc.calculate(_make_query("{A} + {B}", [p1, p2]), _START, _END)
+
+    assert client.time_series.data.retrieve.call_count == 1
+    queries_arg = client.time_series.data.retrieve.call_args.kwargs["instance_id"]
+    assert len(queries_arg) == 1
+    assert list(result.values) == [6.0, 12.0]
+
+
+def test_calculate_raises_on_non_numeric_values_in_window() -> None:
+    param = _make_param("A", external_id="ts_a")
+
+    raw = _make_datapoints_list(
+        {("s", "ts_a"): [1.0, "bad", 3.0]},  # type: ignore[list-item]
+    )
+    calc = Calculator(_client_returning(raw))
+
+    with pytest.raises(ParameterError, match="parameter 'A' must be a numeric"):
+        calc.calculate(_make_query("{A}", [param]), _START, _END)
+
+
+# ---------------------------------------------------------------------------
+# Calculator.calculate_multiples
+# ---------------------------------------------------------------------------
+
+
+def test_calculate_multiples_returns_one_result_per_query() -> None:
+    p_a = _make_param("A", external_id="ts_a")
+    p_b = _make_param("B", external_id="ts_b")
+
+    raw = _make_datapoints_list(
+        {("s", "ts_a"): [1.0, 2.0], ("s", "ts_b"): [10.0, 20.0]}
+    )
+    calc = Calculator(_client_returning(raw))
+
+    results = calc.calculate_multiples(
+        [_make_query("{A} * 2", [p_a]), _make_query("{B} + 1", [p_b])],
+        _START,
+        _END,
+    )
+
+    assert len(results) == 2
+    assert list(results[0].values) == [2.0, 4.0]
+    assert list(results[1].values) == [11.0, 21.0]
+
+
+def test_calculate_multiples_batches_into_single_api_call() -> None:
+    p_a = _make_param("A", external_id="ts_a")
+    p_b = _make_param("B", external_id="ts_b")
+
+    raw = _make_datapoints_list({("s", "ts_a"): [1.0], ("s", "ts_b"): [2.0]})
+    client = _client_returning(raw)
+    Calculator(client).calculate_multiples(
+        [_make_query("{A}", [p_a]), _make_query("{B}", [p_b])],
+        _START,
+        _END,
+    )
+
+    assert client.time_series.data.retrieve.call_count == 1
+    queries_arg = client.time_series.data.retrieve.call_args.kwargs["instance_id"]
+    assert len(queries_arg) == 2
+
+
+def test_calculate_multiples_deduplicates_shared_timeseries_across_queries() -> None:
+    # Both queries reference the same time series — only one API request should
+    # be made for it, but each query gets its own result.
+    p_a = _make_param("A", external_id="ts_shared")
+    p_b = _make_param("B", external_id="ts_shared")
+
+    raw = _make_datapoints_list({("s", "ts_shared"): [5.0, 10.0]})
+    client = _client_returning(raw)
+    results = Calculator(client).calculate_multiples(
+        [_make_query("{A} * 2", [p_a]), _make_query("{B} + 1", [p_b])],
+        _START,
+        _END,
+    )
+
+    queries_arg = client.time_series.data.retrieve.call_args.kwargs["instance_id"]
+    assert len(queries_arg) == 1  # deduplicated to a single fetch
+    assert list(results[0].values) == [10.0, 20.0]
+    assert list(results[1].values) == [6.0, 11.0]
+
+
+def test_calculate_multiples_empty_queries_returns_empty_list() -> None:
+    client = MagicMock()
+    results = Calculator(client).calculate_multiples([], _START, _END)
+
+    assert results == []
+
+
+def test_calculate_multiples_multi_parameter_query() -> None:
+    p_a = _make_param("A", external_id="ts_a")
+    p_b = _make_param("B", external_id="ts_b")
+    p_c = _make_param("C", external_id="ts_c")
+
+    raw = _make_datapoints_list(
+        {
+            ("s", "ts_a"): [4.0, 8.0],
+            ("s", "ts_b"): [2.0, 4.0],
+            ("s", "ts_c"): [1.0, 2.0],
+        }
+    )
+    calc = Calculator(_client_returning(raw))
+
+    results = calc.calculate_multiples(
+        [
+            _make_query("{A} / {B}", [p_a, p_b]),
+            _make_query("{C} * 3", [p_c]),
+        ],
+        _START,
+        _END,
+    )
+
+    assert list(results[0].values) == [2.0, 2.0]
+    assert list(results[1].values) == [3.0, 6.0]

--- a/tests/calculator/test_datapoints_retrieval.py
+++ b/tests/calculator/test_datapoints_retrieval.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal
+from unittest.mock import MagicMock
+
+import pytest
+from cognite.client.data_classes.datapoints import Datapoints, DatapointsList
+
+from industrial_model.calculator.datapoints_retrieval import DatapointsRetriever
+from industrial_model.calculator.models import CalculatorParameter
+from industrial_model.models import InstanceId
+
+_START = datetime(2024, 1, 1, tzinfo=UTC)
+_END = datetime(2024, 1, 2, tzinfo=UTC)
+
+
+def _param(
+    alias: str,
+    *,
+    external_id: str = "x",
+    space: str = "s",
+    aggregate: str | None = None,
+    granularity: str | None = None,
+) -> CalculatorParameter:
+    return CalculatorParameter(
+        alias=alias,
+        timeseries_instance_id=InstanceId(space=space, external_id=external_id),
+        aggregate_type=aggregate,  # type: ignore[arg-type]
+        granularity=granularity,
+    )
+
+
+def _datapoints(
+    *,
+    external_id: str = "x",
+    timestamps: list[int] | None = None,
+    value: list[float] | None = None,
+    dp_type: Literal["numeric", "string", "state"] = "numeric",
+    **aggregate_columns: list[float],
+) -> Datapoints:
+    dp = Datapoints(
+        id=1,
+        is_string=False,
+        is_step=False,
+        type=dp_type,
+        external_id=external_id,
+        instance_id=MagicMock(external_id=external_id),
+        timestamp=timestamps,
+        value=value,
+    )
+    for name, column in aggregate_columns.items():
+        setattr(dp, name, column)
+    return dp
+
+
+def _client_returning(*series: Datapoints) -> MagicMock:
+    raw = MagicMock(spec=DatapointsList)
+    raw.__getitem__.side_effect = lambda idx: series[idx]
+    client = MagicMock()
+    client.time_series.data.retrieve.return_value = raw
+    return client
+
+
+def _base_ms() -> int:
+    return int(_START.timestamp() * 1000)
+
+
+# ---------------------------------------------------------------------------
+# _build_requests
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_without_granularity_raises_value_error() -> None:
+    retriever = DatapointsRetriever(MagicMock())
+    param = _param("A", aggregate="average")
+
+    with pytest.raises(ValueError, match="Missing granularity for 'A'"):
+        retriever.retrieve_datapoints([param], _START, _END)
+
+
+def test_same_timeseries_and_granularity_with_different_aggregates_are_merged() -> None:
+    retriever = DatapointsRetriever(MagicMock())
+    avg = _param("A", aggregate="average", granularity="1h")
+    total = _param("B", aggregate="sum", granularity="1h")
+
+    requests, index_mapping = retriever._build_requests([avg, total], _START, _END)
+
+    assert len(requests) == 1
+    assert requests[0].aggregates == ["average", "sum"]
+    assert index_mapping == {0: 0, 1: 0}
+
+
+def test_repeated_aggregate_on_same_series_is_not_duplicated() -> None:
+    retriever = DatapointsRetriever(MagicMock())
+    first = _param("A", aggregate="average", granularity="1h")
+    second = _param("B", aggregate="average", granularity="1h")
+
+    requests, _ = retriever._build_requests([first, second], _START, _END)
+
+    assert requests[0].aggregates == ["average"]
+
+
+def test_same_timeseries_different_granularity_produces_separate_requests() -> None:
+    retriever = DatapointsRetriever(MagicMock())
+    hourly = _param("A", aggregate="average", granularity="1h")
+    daily = _param("B", aggregate="average", granularity="1d")
+
+    requests, index_mapping = retriever._build_requests([hourly, daily], _START, _END)
+
+    assert len(requests) == 2
+    assert index_mapping == {0: 0, 1: 1}
+
+
+def test_raw_and_aggregate_for_same_series_are_distinct_requests() -> None:
+    retriever = DatapointsRetriever(MagicMock())
+    raw_param = _param("A")
+    agg_param = _param("B", aggregate="average", granularity="1h")
+
+    requests, index_mapping = retriever._build_requests(
+        [raw_param, agg_param], _START, _END
+    )
+
+    assert len(requests) == 2
+    assert requests[0].granularity is None
+    assert requests[1].granularity == "1h"
+
+
+# ---------------------------------------------------------------------------
+# retrieve_datapoints + _parse_datapoints
+# ---------------------------------------------------------------------------
+
+
+def test_merged_aggregates_pull_their_own_column_per_parameter() -> None:
+    base = _base_ms()
+    dp = _datapoints(
+        timestamps=[base, base + 60_000],
+        average=[10.0, 20.0],
+        sum=[100.0, 200.0],
+    )
+    client = _client_returning(dp)
+    retriever = DatapointsRetriever(client)
+
+    avg = _param("A", aggregate="average", granularity="1h")
+    total = _param("B", aggregate="sum", granularity="1h")
+
+    result = retriever.retrieve_datapoints([avg, total], _START, _END)
+
+    assert [value for _, value in result[0]] == [10.0, 20.0]
+    assert [value for _, value in result[1]] == [100.0, 200.0]
+
+
+def test_parse_datapoints_drops_none_values_and_aligns_timestamps() -> None:
+    base = _base_ms()
+    dp = _datapoints(
+        timestamps=[base, base + 60_000, base + 120_000],
+        value=[1.0, None, 3.0],  # type: ignore[list-item]
+    )
+    client = _client_returning(dp)
+    retriever = DatapointsRetriever(client)
+
+    result = retriever.retrieve_datapoints([_param("A")], _START, _END)
+
+    assert [value for _, value in result[0]] == [1.0, 3.0]
+    first_ts = result[0][0][0]
+    assert first_ts == datetime.fromtimestamp(base / 1000, tz=UTC)
+
+
+def test_missing_column_is_treated_as_empty_series() -> None:
+    dp = _datapoints(timestamps=[], value=None)
+    client = _client_returning(dp)
+    retriever = DatapointsRetriever(client)
+
+    result = retriever.retrieve_datapoints([_param("A")], _START, _END)
+
+    assert result == [[]]
+
+
+def test_non_numeric_datapoints_type_is_rejected() -> None:
+    dp = _datapoints(timestamps=[_base_ms()], value=None, dp_type="string")
+    client = _client_returning(dp)
+    retriever = DatapointsRetriever(client)
+
+    with pytest.raises(ValueError, match="expected numeric datapoints"):
+        retriever.retrieve_datapoints([_param("A")], _START, _END)
+
+
+def test_missing_aggregate_column_is_treated_as_empty_series() -> None:
+    # The requested aggregate column is absent (``None``) on the response, e.g.
+    # a series with no data in the window; it should yield an empty series
+    # rather than raising.
+    dp = _datapoints(timestamps=[], average=None)  # type: ignore[arg-type]
+    client = _client_returning(dp)
+    retriever = DatapointsRetriever(client)
+
+    param = _param("A", aggregate="average", granularity="1h")
+    result = retriever.retrieve_datapoints([param], _START, _END)
+
+    assert result == [[]]

--- a/tests/calculator/test_package_api.py
+++ b/tests/calculator/test_package_api.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import industrial_model.calculator as calculator
+from industrial_model.calculator.formula_expression import evaluate
+
+
+def test_public_names_match_all() -> None:
+    # Every name advertised in ``__all__`` must actually be importable, so a
+    # ``from industrial_model.calculator import *`` never raises AttributeError.
+    for name in calculator.__all__:
+        assert hasattr(calculator, name), name
+
+
+def test_evaluate_is_re_exported_from_package() -> None:
+    assert calculator.evaluate is evaluate
+
+
+def test_all_contains_expected_public_surface() -> None:
+    assert set(calculator.__all__) == {
+        "CalculationResult",
+        "Calculator",
+        "CalculatorQuery",
+        "evaluate",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -311,7 +311,7 @@ wheels = [
 
 [[package]]
 name = "industrial-model"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognite-sdk" },
@@ -330,6 +330,8 @@ cli = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "inquirerpy" },
+    { name = "jinja2" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "python-dotenv" },
@@ -353,6 +355,8 @@ provides-extras = ["cli"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "inquirerpy", specifier = ">=0.3.4,<0.4" },
+    { name = "jinja2", specifier = ">=3.1.6,<4" },
     { name = "mypy", specifier = ">=1.20.2,<2" },
     { name = "pytest", specifier = ">=9.1.1,<10" },
     { name = "python-dotenv", specifier = ">=1.2.2,<2" },


### PR DESCRIPTION
Introduce the `industrial_model.calculator` package for evaluating arithmetic formulas over aligned time-series datapoints:

- `Calculator` fetches datapoints via the Cognite client and computes single or batched `CalculatorQuery` results, deduplicating identical time-series/aggregate requests into a single API call.
- `formula_expression` provides a safe, cached AST-based `evaluate`: placeholder parsing, strict validation (rejects unsafe/unsupported syntax and non-numeric constants), constant folding, and element-wise evaluation with scalar broadcasting.
- Well-defined error contract: structural problems raise `FormulaError` subclasses, while value-dependent arithmetic failures surface as native `ZeroDivisionError`/`OverflowError`.
- Guard malformed API responses with explicit `TypeError`/`ValueError` instead of `assert` (safe under `python -O`).

Add extensive test coverage (370 tests) across compilation, evaluation, validation, exceptions, large datasets, representative production formulas, datapoints retrieval, and the public package API.